### PR TITLE
Improve Plaintext Export Compatibility with SMS Backup and Restore

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -111,13 +111,6 @@
     <meta-data android:name="com.google.android.gms.car.application"
                android:resource="@xml/automotive_app_desc" />
 
-    <activity android:name="org.thoughtcrime.redphone.RedPhone"
-              android:excludeFromRecents="true"
-              android:screenOrientation="portrait"
-              android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|fontScale"
-              android:launchMode="singleTask">
-    </activity>
-
     <activity android:name="org.thoughtcrime.securesms.WebRtcCallActivity"
               android:excludeFromRecents="true"
               android:screenOrientation="portrait"
@@ -357,7 +350,7 @@
         </intent-filter>
     </activity>
 
-    <activity android:name="org.thoughtcrime.redphone.VoiceCallShare"
+    <activity android:name="org.thoughtcrime.securesms.webrtc.VoiceCallShare"
               android:excludeFromRecents="true"
               android:theme="@style/NoAnimation.Theme.BlackScreen"
               android:launchMode="singleTask"
@@ -390,7 +383,6 @@
 
     <activity android:name="com.soundcloud.android.crop.CropImageActivity" />
 
-    <service android:enabled="true" android:name="org.thoughtcrime.redphone.RedPhoneService"/>
     <service android:enabled="true" android:name="org.thoughtcrime.securesms.service.WebRtcCallService"/>
 
     <service android:enabled="true" android:name=".service.ApplicationMigrationService"/>

--- a/build.gradle
+++ b/build.gradle
@@ -197,8 +197,8 @@ android {
     }
 
     defaultConfig {
-        versionCode 250
-        versionName "4.0.0"
+        versionCode 251
+        versionName "4.0.1"
 
         minSdkVersion 9
         targetSdkVersion 22

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     compile 'org.whispersystems:jobmanager:1.0.2'
     compile 'org.whispersystems:libpastelog:1.0.7'
     compile 'org.whispersystems:signal-service-android:2.5.3'
-    compile 'org.whispersystems:webrtc-android:M57'
+    compile 'org.whispersystems:webrtc-android:M57-S1'
 
     compile "me.leolin:ShortcutBadger:1.10-WS1"
     compile 'se.emilsjolander:stickylistheaders:2.7.0'
@@ -130,7 +130,7 @@ dependencyVerification {
         'org.whispersystems:jobmanager:506f679fc2fcf7bb6d10f00f41d6f6ea0abf75c70dc95b913398661ad538a181',
         'org.whispersystems:libpastelog:bb331d9a98240fc139101128ba836c1edec3c40e000597cdbb29ebf4cbf34d88',
         'org.whispersystems:signal-service-android:28a5368cb1336106ba7732aeaf0c5a33ef8fb22500c41f38ad8147375f59073b',
-        'org.whispersystems:webrtc-android:acf78f6148c2e946b846cc5395887079ba37ddb892bf0d993fed18f1b9f521f8',
+        'org.whispersystems:webrtc-android:bcca87cfe5c81226184d841b09d1163b3199f046367d1cc8682651673199948b',
         'me.leolin:ShortcutBadger:e8e39df8a59d8211a30f40b1eeab21b3fa57b3f3e0f03abb995f82d66588778c',
         'se.emilsjolander:stickylistheaders:a08ca948aa6b220f09d82f16bbbac395f6b78897e9eeac6a9f0b0ba755928eeb',
         'com.jpardogo.materialtabstrip:library:c6ef812fba4f74be7dc4a905faa4c2908cba261a94c13d4f96d5e67e4aad4aaa',
@@ -185,7 +185,6 @@ dependencyVerification {
         'com.android.support:support-fragment:1294500b357f52cf3779e2521c79f54ae7844f3b9a5f6727495dbbda7f231377',
     ]
 }
-
 
 android {
     compileSdkVersion 25

--- a/build.gradle
+++ b/build.gradle
@@ -196,8 +196,8 @@ android {
     }
 
     defaultConfig {
-        versionCode 251
-        versionName "4.0.1"
+        versionCode 252
+        versionName "4.1.0"
 
         minSdkVersion 9
         targetSdkVersion 22

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     compile 'org.whispersystems:jobmanager:1.0.2'
     compile 'org.whispersystems:libpastelog:1.0.7'
     compile 'org.whispersystems:signal-service-android:2.5.3'
-    compile 'org.whispersystems:webrtc-android:M57'
+    compile 'org.whispersystems:webrtc-android:M57-S2'
 
     compile "me.leolin:ShortcutBadger:1.10-WS1"
     compile 'se.emilsjolander:stickylistheaders:2.7.0'
@@ -130,7 +130,7 @@ dependencyVerification {
         'org.whispersystems:jobmanager:506f679fc2fcf7bb6d10f00f41d6f6ea0abf75c70dc95b913398661ad538a181',
         'org.whispersystems:libpastelog:bb331d9a98240fc139101128ba836c1edec3c40e000597cdbb29ebf4cbf34d88',
         'org.whispersystems:signal-service-android:28a5368cb1336106ba7732aeaf0c5a33ef8fb22500c41f38ad8147375f59073b',
-        'org.whispersystems:webrtc-android:acf78f6148c2e946b846cc5395887079ba37ddb892bf0d993fed18f1b9f521f8',
+        'org.whispersystems:webrtc-android:9d11e39d4b3823713e5b1486226e0ce09f989d6f47f52da1815e406c186701d5',
         'me.leolin:ShortcutBadger:e8e39df8a59d8211a30f40b1eeab21b3fa57b3f3e0f03abb995f82d66588778c',
         'se.emilsjolander:stickylistheaders:a08ca948aa6b220f09d82f16bbbac395f6b78897e9eeac6a9f0b0ba755928eeb',
         'com.jpardogo.materialtabstrip:library:c6ef812fba4f74be7dc4a905faa4c2908cba261a94c13d4f96d5e67e4aad4aaa',
@@ -185,7 +185,6 @@ dependencyVerification {
         'com.android.support:support-fragment:1294500b357f52cf3779e2521c79f54ae7844f3b9a5f6727495dbbda7f231377',
     ]
 }
-
 
 android {
     compileSdkVersion 25

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     compile 'org.whispersystems:jobmanager:1.0.2'
     compile 'org.whispersystems:libpastelog:1.0.7'
     compile 'org.whispersystems:signal-service-android:2.5.3'
-    compile 'org.whispersystems:webrtc-android:M57-S1'
+    compile 'org.whispersystems:webrtc-android:M57'
 
     compile "me.leolin:ShortcutBadger:1.10-WS1"
     compile 'se.emilsjolander:stickylistheaders:2.7.0'
@@ -130,7 +130,7 @@ dependencyVerification {
         'org.whispersystems:jobmanager:506f679fc2fcf7bb6d10f00f41d6f6ea0abf75c70dc95b913398661ad538a181',
         'org.whispersystems:libpastelog:bb331d9a98240fc139101128ba836c1edec3c40e000597cdbb29ebf4cbf34d88',
         'org.whispersystems:signal-service-android:28a5368cb1336106ba7732aeaf0c5a33ef8fb22500c41f38ad8147375f59073b',
-        'org.whispersystems:webrtc-android:bcca87cfe5c81226184d841b09d1163b3199f046367d1cc8682651673199948b',
+        'org.whispersystems:webrtc-android:acf78f6148c2e946b846cc5395887079ba37ddb892bf0d993fed18f1b9f521f8',
         'me.leolin:ShortcutBadger:e8e39df8a59d8211a30f40b1eeab21b3fa57b3f3e0f03abb995f82d66588778c',
         'se.emilsjolander:stickylistheaders:a08ca948aa6b220f09d82f16bbbac395f6b78897e9eeac6a9f0b0ba755928eeb',
         'com.jpardogo.materialtabstrip:library:c6ef812fba4f74be7dc4a905faa4c2908cba261a94c13d4f96d5e67e4aad4aaa',
@@ -185,6 +185,7 @@ dependencyVerification {
         'com.android.support:support-fragment:1294500b357f52cf3779e2521c79f54ae7844f3b9a5f6727495dbbda7f231377',
     ]
 }
+
 
 android {
     compileSdkVersion 25

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -358,6 +358,8 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Получихте съобщение криптирано със стара версия на Сигнал, която вече не се поддържа. Моля помолете изпращача да обнови версията си и да препрати съобщението.</string>
   <string name="MessageRecord_left_group">Напуснахте групата.</string>
+  <string name="MessageRecord_you_updated_group">Обновихте групата.</string>
+  <string name="MessageRecord_s_updated_group">%s обнови групата.</string>
   <string name="MessageRecord_s_called_you">%s ти се обади</string>
   <string name="MessageRecord_called_s">Обаждане до %s</string>
   <string name="MessageRecord_missed_call_from">Пропуснато обаждане от %s</string>
@@ -368,7 +370,7 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <!--PassphraseChangeActivity-->
   <string name="PassphraseChangeActivity_passphrases_dont_match_exclamation">Паролите не съвпадат!</string>
   <string name="PassphraseChangeActivity_incorrect_old_passphrase_exclamation">Грешна стара парола!</string>
-  <string name="PassphraseChangeActivity_enter_new_passphrase_exclamation">Въведи нова парола!</string>
+  <string name="PassphraseChangeActivity_enter_new_passphrase_exclamation">Въведете нова парола!</string>
   <!--DeviceProvisioningActivity-->
   <string name="DeviceProvisioningActivity_link_this_device">Свържи това устройство?</string>
   <string name="DeviceProvisioningActivity_cancel">ОТКАЖИ</string>
@@ -394,7 +396,7 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <string name="ExpirationDialog_your_messages_will_not_expire">Съобщението Ви няма да изчезне.</string>
   <string name="ExpirationDialog_your_messages_will_disappear_s_after_they_have_been_seen">Изпратени и получени съобщения в този разговор ще изчезнат %s след изпращането им.</string>
   <!--PassphrasePromptActivity-->
-  <string name="PassphrasePromptActivity_enter_passphrase">Въведи паролата</string>
+  <string name="PassphrasePromptActivity_enter_passphrase">Въведете паролата</string>
   <string name="PassphrasePromptActivity_watermark_content_description">Сигнал икона</string>
   <string name="PassphrasePromptActivity_ok_button_content_description">Задай паролата</string>
   <string name="PassphrasePromptActivity_invalid_passphrase_exclamation">Грешна парола!</string>
@@ -502,6 +504,7 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <string name="SmsMessageRecord_secure_session_reset_s">%s рестартира сигурната сесия.</string>
   <string name="SmsMessageRecord_duplicate_message">Дублирай съобщението.</string>
   <!--ThreadRecord-->
+  <string name="ThreadRecord_group_updated">Групата е обновена</string>
   <string name="ThreadRecord_left_the_group">Напусна групата</string>
   <string name="ThreadRecord_secure_session_reset">Започване на нова сигурна сесия.</string>
   <string name="ThreadRecord_draft">Чернова:</string>
@@ -617,7 +620,7 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <string name="change_passphrase_activity__new_passphrase">Нова парола</string>
   <string name="change_passphrase_activity__repeat_new_passphrase">Повторете новата парола</string>
   <!--contact_selection_activity-->
-  <string name="contact_selection_activity__enter_name_or_number">Въведи име или номер</string>
+  <string name="contact_selection_activity__enter_name_or_number">Въведете име или номер</string>
   <!--contact_selection_group_activity-->
   <string name="contact_selection_group_activity__no_contacts">Няма контакти.</string>
   <string name="contact_selection_group_activity__finding_contacts">Зареждане на контакти...</string>
@@ -746,6 +749,7 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <!--message_recipients_list_item-->
   <string name="message_recipients_list_item__verify">ПОТВЪРДИ</string>
   <string name="message_recipients_list_item__resend">ИЗПРАТИ ПОВТОРНО</string>
+  <string name="message_recipients_list_item__resending">Повторно изпращане...</string>
   <!--GroupUtil-->
   <plurals name="GroupUtil_joined_the_group">
     <item quantity="one">%1$s се присъедини към групата.</item>
@@ -801,8 +805,8 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <!--registration_progress_activity-->
   <string name="registration_progress_activity__voice_verification">Гласово потвърждение</string>
   <string name="registration_progress_activity__signal_can_also_call_you_to_verify_your_number">
-Сигнал може да ти се обади, за да потвърди номера ти. Натисни \'Обади ми се\' и въведи 6 цифрения код, 
-който чуваш, долу.</string>
+Сигнал може да Ви се обади, за да потвърди номера Ви. Натиснете \'Обади ми се\' и въведи 6 цифрения код, 
+който чуете, долу.</string>
   <string name="registration_progress_activity__verify">Потвърди</string>
   <string name="registration_progress_activity__call_me">Обади ми се</string>
   <string name="registration_progress_activity__edit_number">Промени номера</string>
@@ -837,7 +841,7 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <string name="registration_progress_activity__telephone">Телефон</string>
   <string name="registration_progress_activity__check">Провери</string>
   <!--recipients_panel-->
-  <string name="recipients_panel__to"><small>Въведи име или номер</small></string>
+  <string name="recipients_panel__to"><small>Въведете име или номер</small></string>
   <string name="recipients_panel__add_members">Добавяне на членове</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s"><![CDATA[Ако желаете да проверите сигурността на вашта комуникация с %s, сравнете числата изписани по-горе с числата на тяхното устройство. Или, можете да сканирате техния код или те да сканират Вашия. <a href="https://whispersystems.org/redirect/safety-numbers">Научете повече за проверката за сигурност с числа</a>.]]></string>
@@ -855,15 +859,15 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <string name="message_details_header__with">С:</string>
   <!--AndroidManifest.xml-->
   <string name="AndroidManifest__create_passphrase">Създай парола</string>
-  <string name="AndroidManifest__enter_passphrase">Въведи парола</string>
+  <string name="AndroidManifest__enter_passphrase">Въведете парола</string>
   <string name="AndroidManifest__select_contacts">Избери контакти</string>
   <string name="AndroidManifest__signal_detected">Открит е Сигнал</string>
   <string name="AndroidManifest__change_passphrase">Смени паролата</string>
   <string name="AndroidManifest__verify_safety_number">Проверка на числата за сигурност</string>
   <string name="AndroidManifest__log_submit">Изпрати доклад</string>
   <string name="AndroidManifest__media_preview">Преглед на медията</string>
-  <string name="AndroidManifest__all_media">Всяка медия</string>
-  <string name="AndroidManifest__all_media_named">Всяка медия с %1$s</string>
+  <string name="AndroidManifest__all_media">Всички медии</string>
+  <string name="AndroidManifest__all_media_named">Всички медии с %1$s</string>
   <string name="AndroidManifest__message_details">Информация за съобщението</string>
   <string name="AndroidManifest__linked_devices">Свързани устройства</string>
   <string name="AndroidManifest__invite_friends">Поканете приятели</string>
@@ -1057,7 +1061,7 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <string name="conversation__menu_edit_group">Промяна на групата</string>
   <string name="conversation__menu_leave_group">Напусни група</string>
   <string name="conversation__menu_delete_thread">Изтрий разговор</string>
-  <string name="conversation__menu_view_all_media">Всяка медия</string>
+  <string name="conversation__menu_view_all_media">Всички медии</string>
   <string name="conversation__menu_conversation_settings">Настройки на разговора</string>
   <!--conversation_popup-->
   <string name="conversation_popup__menu_expand_popup">Разшири диалога</string>
@@ -1112,7 +1116,7 @@ SMS-те от системния архив в Сигнал. Ако вече с�
   <!--media_preview-->
   <string name="media_preview__save_title">Запази</string>
   <string name="media_preview__forward_title">Препращане</string>
-  <string name="media_preview__all_media_title">Всяка медия</string>
+  <string name="media_preview__all_media_title">Всички медии</string>
   <!--media_overview-->
   <string name="media_overview__save_all">Запази всички</string>
   <!--media_preview_activity-->

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -353,8 +353,8 @@ Das Wiederherstellen einer verschlüsselten Datensicherung ersetzt deine bestehe
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Die empfangene Nachricht wurde mit einer veralteten Version von Signal verschlüsselt, die nicht mehr unterstützt wird. Bitte den Absender, Signal zu aktualisieren und die Nachricht erneut zu senden.</string>
   <string name="MessageRecord_left_group">Du hast die Gruppe verlassen</string>
-  <string name="MessageRecord_you_updated_group">Du hast die Gruppe aktualisiert.</string>
-  <string name="MessageRecord_s_updated_group">%s hat die Gruppe aktualisiert.</string>
+  <string name="MessageRecord_you_updated_group">Du hast die Gruppe aktualisiert</string>
+  <string name="MessageRecord_s_updated_group">%s hat die Gruppe aktualisiert</string>
   <string name="MessageRecord_s_called_you">Eingegangener Anruf von %s</string>
   <string name="MessageRecord_called_s">Ausgegangener Anruf an %s</string>
   <string name="MessageRecord_missed_call_from">Entgangener Anruf von %s</string>
@@ -484,16 +484,16 @@ Bitte kontrolliere noch einmal deine Rufnummer. Diese wird anschließend durch e
   <string name="Slide_audio">Audio</string>
   <string name="Slide_video">Video</string>
   <!--SmsMessageRecord-->
-  <string name="SmsMessageRecord_received_corrupted_key_exchange_message">Fehlerhafte Schlüsselaustausch-Nachricht empfangen!</string>
+  <string name="SmsMessageRecord_received_corrupted_key_exchange_message">Fehlerhafte Schlüsselaustausch-Nachricht empfangen</string>
   <string name="SmsMessageRecord_received_key_exchange_message_for_invalid_protocol_version">
-Schlüsselaustausch-Nachricht für eine ungültige Protokollversion empfangen.</string>
+Schlüsselaustausch-Nachricht für eine ungültige Protokollversion empfangen</string>
   <string name="SmsMessageRecord_received_message_with_new_safety_number_tap_to_process">Nachricht mit neuer Sicherheitsnummer empfangen. Zum Verarbeiten und Anzeigen antippen.</string>
-  <string name="SmsMessageRecord_secure_session_reset">Du hast die Verschlüsselung neu gestartet.</string>
-  <string name="SmsMessageRecord_secure_session_reset_s">%s hat die Verschlüsselung neu gestartet.</string>
-  <string name="SmsMessageRecord_duplicate_message">Doppelte Nachricht.</string>
+  <string name="SmsMessageRecord_secure_session_reset">Du hast die Verschlüsselung neu gestartet</string>
+  <string name="SmsMessageRecord_secure_session_reset_s">%s hat die Verschlüsselung neu gestartet</string>
+  <string name="SmsMessageRecord_duplicate_message">Doppelte Nachricht</string>
   <!--ThreadRecord-->
   <string name="ThreadRecord_group_updated">Gruppe aktualisiert</string>
-  <string name="ThreadRecord_left_the_group">Gruppe wurde verlassen</string>
+  <string name="ThreadRecord_left_the_group">Gruppe verlassen</string>
   <string name="ThreadRecord_secure_session_reset">Verschlüsselung neu gestartet</string>
   <string name="ThreadRecord_draft">Entwurf:</string>
   <string name="ThreadRecord_called">Ausgegangener Anruf</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -219,7 +219,7 @@
   <string name="DateUtils_yesterday">Χθες</string>
   <!--DeviceListActivity-->
   <string name="DeviceListActivity_unlink_s">Αποσύνδεση του \'%s\';</string>
-  <string name="DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive">Αποσυνδέοντας αυτή την συσκευή, αυτή δεν θα μπορεί να λάβει ή να στείλει μηνύματα πια.</string>
+  <string name="DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive">Αποσυνδέοντας αυτή την συσκευή, αυτή δεν θα μπορεί πλέον να λάβει ή να στείλει μηνύματα.</string>
   <string name="DeviceListActivity_network_connection_failed">Αποτυχία σύνδεσης στο δίκτυο</string>
   <string name="DeviceListActivity_try_again">Ξαναπροσπάθησε</string>
   <string name="DeviceListActivity_unlinking_device">Η συσκευή αποσυνδέεται...</string>
@@ -227,8 +227,8 @@
   <string name="DeviceListActivity_network_failed">Αποτυχία δικτύου!</string>
   <!--DeviceListItem-->
   <string name="DeviceListItem_unnamed_device">Ανώνυμη συσκευή</string>
-  <string name="DeviceListItem_linked_s">Συνδεδεμένο %s</string>
-  <string name="DeviceListItem_last_active_s">Τελευταία ενεργό %s</string>
+  <string name="DeviceListItem_linked_s">Συνδέθηκε: %s</string>
+  <string name="DeviceListItem_last_active_s">Τελευταία ενεργή: %s</string>
   <string name="DeviceListItem_today">Σήμερα</string>
   <!--DozeReminder-->
   <string name="DozeReminder_optimize_for_missing_play_services">Βελτιστοποίηση για τις υπηρεσίες Play που λείπουν</string>
@@ -280,7 +280,7 @@
   <string name="GroupCreateActivity_updating_group">Ενημέρωση %1$s...</string>
   <string name="GroupCreateActivity_cannot_add_non_push_to_existing_group">Δεν μπορέσαμε να προσθέσουμε τον/την %1$s επειδή δεν είναι χρήστης του Signal.</string>
   <string name="GroupCreateActivity_loading_group_details">Φόρτωση λεπτομέρειων ομάδας...</string>
-  <string name="GroupCreateActivity_youre_already_in_the_group">Είσαι ήδη μέλος αυτής της ομάδας</string>
+  <string name="GroupCreateActivity_youre_already_in_the_group">Είσαι ήδη μέλος αυτής της ομάδας.</string>
   <!--GroupMembersDialog-->
   <string name="GroupMembersDialog_me">Εγώ</string>
   <!--ImportExportActivity-->
@@ -362,33 +362,35 @@
   <string name="NotificationMmsMessageRecord_downloading_mms_message">Λήψη του μηνύματος MMS</string>
   <string name="NotificationMmsMessageRecord_error_downloading_mms_message">Πρόβλημα με τη λήψη μηνύματος MMS, πάτα για να ξαναδοκιμάσουμε</string>
   <!--MessageRecord-->
-  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Λήφθηκε ένα μήνυμα που είναι κρυπτογραφημένο με μια παλιά έκδοση του Signal που δεν υποστηρίζεται πια. Παρακαλώ ζήτησε από τον αποστολέα να αναβαθμίσει στην πιο πρόσφατη έκδοση και να ξαναστείλει το μήνυμα.</string>
-  <string name="MessageRecord_left_group">Αποχωρήσατε από την ομάδα.</string>
+  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Λήφθηκε ένα μήνυμα που είναι κρυπτογραφημένο με μια παλιά έκδοση του Signal που πλέον δεν υποστηρίζεται. Παρακαλώ ζήτησε από τον αποστολέα να αναβαθμίσει στην πιο πρόσφατη έκδοση και να ξαναστείλει το μήνυμα.</string>
+  <string name="MessageRecord_left_group">Αποχώρησες από την ομάδα.</string>
+  <string name="MessageRecord_you_updated_group">Ενημέρωσες την ομάδα.</string>
+  <string name="MessageRecord_s_updated_group">Ο/Η %s ενημέρωσε την ομάδα.</string>
   <string name="MessageRecord_s_called_you">O/H %s σε κάλεσε</string>
-  <string name="MessageRecord_called_s">Κλήση προς τον/την %s</string>
+  <string name="MessageRecord_called_s">Κάλεσες τον/την %s</string>
   <string name="MessageRecord_missed_call_from">Αναπάντητη κλήση από τον/την %s</string>
   <string name="MessageRecord_s_is_on_signal_say_hey">Ο/Η %s είναι στο Signal, πες ένα γεια!</string>
-  <string name="MessageRecord_you_set_disappearing_message_time_to_s">Ο χρόνος που όρισες για την εξαφάνιση του μηνύματος είναι %1$s.</string>
-  <string name="MessageRecord_s_set_disappearing_message_time_to_s">Ο/Η %1$s όρισε το χρόνο εξαφάνισης του μηνύματος τα %2$s.</string>
+  <string name="MessageRecord_you_set_disappearing_message_time_to_s">Όρισες το χρόνο εξαφάνισης των μηνυμάτων σε: %1$s</string>
+  <string name="MessageRecord_s_set_disappearing_message_time_to_s">Ο/Η %1$s όρισε το χρόνο εξαφάνισης των μηνυμάτων σε: %2$s</string>
   <string name="MessageRecord_your_safety_number_with_s_has_changed">Ο αριθμός ασφαλείας με τον/την %s έχει αλλάξει.</string>
   <!--PassphraseChangeActivity-->
   <string name="PassphraseChangeActivity_passphrases_dont_match_exclamation">Τα συνθηματικά δε ταιριάζουν!</string>
-  <string name="PassphraseChangeActivity_incorrect_old_passphrase_exclamation">Λανθασμένο, παλιό συνθηματικό!</string>
+  <string name="PassphraseChangeActivity_incorrect_old_passphrase_exclamation">Λάθος παλιό συνθηματικό!</string>
   <string name="PassphraseChangeActivity_enter_new_passphrase_exclamation">Εισαγωγή νέου συνθηματικού! </string>
   <!--DeviceProvisioningActivity-->
   <string name="DeviceProvisioningActivity_link_this_device">Σύνδεση αυτής της συσκευής;</string>
   <string name="DeviceProvisioningActivity_cancel">ΑΚΥΡΩΣΗ</string>
   <string name="DeviceProvisioningActivity_continue">ΣΥΝΕΧΕΙΑ</string>
   <string name="DeviceProvisioningActivity_title">Σύνδεση αυτής της συσκευής;</string>
-  <string name="DeviceProvisioningActivity_content_intro">Θα είναι σε θέση να</string>
+  <string name="DeviceProvisioningActivity_content_intro">Θα μπορεί πλέον να</string>
   <string name="DeviceProvisioningActivity_content_bullets">
 • Να διαβάζει όλα τα μηνύματά σου
-\n• Να στέλνει μηνύματα σαν εσένα</string>
+\n• Να στέλνει μηνύματα σαν να είσαι εσύ</string>
   <string name="DeviceProvisioningActivity_content_progress_title">Σύνδεση συσκευής</string>
   <string name="DeviceProvisioningActivity_content_progress_content">Σύνδεση νέας συσκευής...</string>
   <string name="DeviceProvisioningActivity_content_progress_success">Η συσκευή εγκρίθηκε!</string>
   <string name="DeviceProvisioningActivity_content_progress_no_device">Δεν βρέθηκε συσκευή.</string>
-  <string name="DeviceProvisioningActivity_content_progress_network_error">Σφάλμα δικτύου</string>
+  <string name="DeviceProvisioningActivity_content_progress_network_error">Σφάλμα δικτύου.</string>
   <string name="DeviceProvisioningActivity_content_progress_key_error">Άκυρος QR κωδικός.</string>
   <string name="DeviceProvisioningActivity_sorry_you_have_too_many_devices_linked_already">Δυστυχώς έχεις υπερβολικό αριθμό συσκευών συνδεδεμένες, προσπάθησε να διαγράψεις μερικές</string>
   <string name="DeviceActivity_sorry_this_is_not_a_valid_device_link_qr_code">Συγγνώμη, αυτός δεν είναι ένας έγκυρος κωδικός QR για σύνδεση συσκευών.</string>
@@ -404,17 +406,17 @@
   <string name="PassphrasePromptActivity_ok_button_content_description">Καταχώρηση συνθηματικού</string>
   <string name="PassphrasePromptActivity_invalid_passphrase_exclamation">Άκυρο συνθηματικό!</string>
   <!--PlayServicesProblemFragment-->
-  <string name="PlayServicesProblemFragment_the_version_of_google_play_services_you_have_installed_is_not_functioning">Η έκδοση του Google Play Services που έχεις εγκαταστήσει δεν λειτουργεί σωστά. Παρακαλούμε επανεγκατέστησε το Google Play Services και δοκίμασε ξανά.</string>
+  <string name="PlayServicesProblemFragment_the_version_of_google_play_services_you_have_installed_is_not_functioning">Η έκδοση των Υπηρεσιών Google Play που έχεις εγκαταστήσει δεν λειτουργεί σωστά. Παρακαλούμε επανεγκατέστησε τις Υπηρεσίες Google Play και δοκίμασε ξανά.</string>
   <!--RatingManager-->
   <string name="RatingManager_rate_this_app">Βαθμολόγησε αυτή την εφαρμογή</string>
-  <string name="RatingManager_if_you_enjoy_using_this_app_please_take_a_moment">Αν σου αρέσει αυτή την εφαρμογή, βοήθησέ μας βαθμολογώντας την - δεν θα σου πάρει πολύ χρόνο.</string>
+  <string name="RatingManager_if_you_enjoy_using_this_app_please_take_a_moment">Αν σου αρέσει αυτή η εφαρμογή, βοήθησέ μας βαθμολογώντας την - δεν θα σου πάρει πολύ χρόνο.</string>
   <string name="RatingManager_rate_now">Βαθμολόγηση τώρα!</string>
-  <string name="RatingManager_no_thanks">Οχι ευχαριστώ</string>
+  <string name="RatingManager_no_thanks">Όχι, ευχαριστώ</string>
   <string name="RatingManager_later">Αργότερα</string>
   <string name="RatingManager_whoops_the_play_store_app_does_not_appear_to_be_installed">Ουπς, δεν φαίνεται να έχεις εγκατεστημένη την εφαρμογή Play Store στην συσκευή σου.</string>
   <!--RecipientPreferencesActivity-->
   <string name="RecipientPreferenceActivity_block_this_contact_question">Μπλοκάρισμα αυτής της επαφής;</string>
-  <string name="RecipientPreferenceActivity_you_will_no_longer_receive_messages_and_calls_from_this_contact">Δεν θα λαμβάνεις μηνύματα και κλήσεις από αυτή την επαφή πια.</string>
+  <string name="RecipientPreferenceActivity_you_will_no_longer_receive_messages_and_calls_from_this_contact">Δεν θα λαμβάνεις πλέον μηνύματα και κλήσεις από αυτή την επαφή.</string>
   <string name="RecipientPreferenceActivity_block">Μπλοκάρισμα</string>
   <string name="RecipientPreferenceActivity_unblock_this_contact_question">Ξεμπλοκάρισμα αυτής της επαφής;</string>
   <string name="RecipientPreferenceActivity_you_will_once_again_be_able_to_receive_messages_and_calls_from_this_contact">Θα μπορείς και πάλι να λαμβάνεις μηνύματα και κλήσεις από αυτή την επαφή.</string>
@@ -507,7 +509,8 @@
   <string name="SmsMessageRecord_secure_session_reset_s">Ο/Η %s επανεκκίνησε την ασφαλή συνεδρία.</string>
   <string name="SmsMessageRecord_duplicate_message">Διπλότυπο μήνυμα.</string>
   <!--ThreadRecord-->
-  <string name="ThreadRecord_left_the_group">Έφυγε από το group</string>
+  <string name="ThreadRecord_group_updated">Η ομάδα ενημερώθηκε</string>
+  <string name="ThreadRecord_left_the_group">Έφυγες από την ομάδα</string>
   <string name="ThreadRecord_secure_session_reset">Επαναφορά ασφαλούς συνεδρίας.</string>
   <string name="ThreadRecord_draft">Πρόχειρο:</string>
   <string name="ThreadRecord_called">Τον/την κάλεσες</string>
@@ -515,7 +518,7 @@
   <string name="ThreadRecord_missed_call">Αναπάντητη κλήση</string>
   <string name="ThreadRecord_media_message">Μήνυμα πολυμέσων</string>
   <string name="ThreadRecord_s_is_on_signal_say_hey">Ο/Η %s είναι στο Signal, πες ένα γεια!</string>
-  <string name="ThreadRecord_disappearing_message_time_updated_to_s">Ο χρόνος εξαφάνισης μηνυμάτων ρυθμίστηκε σε %s</string>
+  <string name="ThreadRecord_disappearing_message_time_updated_to_s">Ο χρόνος εξαφάνισης των μηνυμάτων ρυθμίστηκε σε %s</string>
   <string name="ThreadRecord_your_safety_number_with_s_has_changed">Ο αριθμός ασφαλείας με τον/την %s έχει αλλάξει.</string>
   <!--UpdateApkReadyListener-->
   <string name="UpdateApkReadyListener_Signal_update">Αναβάθμιση Signal</string>
@@ -614,8 +617,8 @@
   <string name="attachment_type_selector__camera_description">Κάμερα</string>
   <string name="attachment_type_selector__location">Τοποθεσία</string>
   <string name="attachment_type_selector__location_description">Τοποθεσία</string>
-  <string name="attachment_type_selector__gif">Κινούμενη εικόνα</string>
-  <string name="attachment_type_selector__gif_description">Κινούμενη εικόνα</string>
+  <string name="attachment_type_selector__gif">GIF</string>
+  <string name="attachment_type_selector__gif_description">Gif</string>
   <string name="attachment_type_selector__drawer_description">Εναλλαγή συρταριού επισυνημμένων</string>
   <!--change_passphrase_activity-->
   <string name="change_passphrase_activity__old_passphrase">Παλιό συνθηματικό</string>
@@ -750,7 +753,8 @@
   <string name="media_overview_activity__no_media">Κανένα πολυμέσο</string>
   <!--message_recipients_list_item-->
   <string name="message_recipients_list_item__verify">ΕΠΑΛΗΘΕΥΣΗ</string>
-  <string name="message_recipients_list_item__resend">ΑΠΟΣΤΟΛΗ ΞΑΝΑ</string>
+  <string name="message_recipients_list_item__resend">ΕΠΑΝΑΠΟΣΤΟΛΗ</string>
+  <string name="message_recipients_list_item__resending">Επαναποστολή...</string>
   <!--GroupUtil-->
   <plurals name="GroupUtil_joined_the_group">
     <item quantity="one">Ο/Η %1$s μπήκε στην ομάδα.</item>
@@ -852,7 +856,7 @@
   <string name="recipients_panel__to"><small>Εισαγωγή ονόματος ή αριθμού</small></string>
   <string name="recipients_panel__add_members">Προσθήκη μελών</string>
   <!--verify_display_fragment-->
-  <string name="verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s"><![CDATA[Αν θέλεις να επιβεβαιώσεις την ασφάλεια της κρυπτογράφισης από άκρο σε άκρο %s, σύγκρινε τον παρακάτω αριθμό με τον αριθμό στην συσκευή. Εναλλακτικά, μπορείς να σκανάρεις τον κωδικό στην οθόνη του κινητού τους, ή να τους ζητήσεις να σκανάρουν τον δικό σου κωδικό. <a href="https://whispersystems.org/redirect/safety-numbers">Μάθε περισσότερα για την επιβεβαίωση του αριθμού ασφαλείας</a>]]></string>
+  <string name="verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s"><![CDATA[Αν θέλεις να επιβεβαιώσεις την ασφάλεια της κρυπτογραφίας από άκρο σε άκρο με τον/την %s, σύγκρινε τον παρακάτω αριθμό με τον αριθμό στην συσκευή του/της. Εναλλακτικά, μπορείς να σκανάρεις τον κωδικό στην οθόνη του κινητού του/της, ή να τους ζητήσεις να σκανάρουν τον δικό σου κωδικό. <a href="https://whispersystems.org/redirect/safety-numbers">Μάθε περισσότερα για την επιβεβαίωση του αριθμού ασφαλείας.</a>]]></string>
   <string name="verify_display_fragment__tap_to_scan">Πάτα για σκανάρισμα</string>
   <!--verify_identity-->
   <string name="verify_identity__share_safety_number">Μοιράσου τον αριθμό ασφαλείας</string>
@@ -896,7 +900,7 @@
   <string name="arrays__name_only">Μόνο όνομα</string>
   <string name="arrays__no_name_or_message">Χωρίς όνομα ή μήνυμα</string>
   <string name="arrays__images">Εικόνες</string>
-  <string name="arrays__audio">Ήχος</string>
+  <string name="arrays__audio">Ήχοι</string>
   <string name="arrays__video">Βίντεο</string>
   <!--plurals.xml-->
   <plurals name="hours_ago">
@@ -958,7 +962,7 @@
   <string name="preferences__red">Κόκκινο</string>
   <string name="preferences__blue">Μπλε</string>
   <string name="preferences__orange">Πορτοκαλί</string>
-  <string name="preferences__cyan">Κύανο</string>
+  <string name="preferences__cyan">Γαλάζιο</string>
   <string name="preferences__magenta">Φούξια</string>
   <string name="preferences__white">Λευκό</string>
   <string name="preferences__none">Κανένα</string>
@@ -975,8 +979,8 @@
   <string name="preferences__mmsc_url">MMSC URL</string>
   <string name="preferences__mms_proxy_host">MMS Διακομιστής Διαμεσολάβησης</string>
   <string name="preferences__mms_proxy_port">Θύρα Διακομιστή Μεσολάβησης MMS</string>
-  <string name="preferences__mmsc_username">MMSC Όνομα Χρήστη</string>
-  <string name="preferences__mmsc_password">MMSC Κωδικός`</string>
+  <string name="preferences__mmsc_username">Όνομα Χρήστη MMSC</string>
+  <string name="preferences__mmsc_password">Κωδικός MMSC</string>
   <string name="preferences__sms_delivery_reports">Αναφορές παράδοσης SMS</string>
   <string name="preferences__request_a_delivery_report_for_each_sms_message_you_send">Αίτημα αναφοράς παράδοσης για κάθε SMS που στέλνεις</string>
   <string name="preferences__automatically_delete_older_messages_once_a_conversation_exceeds_a_specified_length">Αυτόματη διαγραφή παλαιότερων μηνυμάτων όταν μια συνομιλία ξεπεράσει ένα ορισμένο μήκος</string>
@@ -990,13 +994,13 @@
   <string name="preferences__dark_theme">Σκοτεινό</string>
   <string name="preferences__appearance">Εμφάνιση</string>
   <string name="preferences__theme">Θέμα</string>
-  <string name="preferences__default">Προκαθορισμένη</string>
+  <string name="preferences__default">Προκαθορισμένο</string>
   <string name="preferences__language">Γλώσσα</string>
   <string name="preferences__signal_messages_and_calls">Μηνύματα και κλήσεις του Signal</string>
   <string name="preferences__free_private_messages_and_calls">Δωρεάν προσωπικά μηνύματα και κλήσεις προς τους χρήστες του Signal</string>
   <string name="preferences__submit_debug_log">Αποστολή αρχείου συμβάντων αποσφαλμάτωσης</string>
   <string name="preferences__support_wifi_calling">Λειτουργία συμβατότητας \"WiFi Calling\' </string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Ενεργοποίηση αν η συσκευή σου χρησιμοποιεί παράδοση SMS/MMS μέσω WiFi (ενεργοποίηση μόνο αν το \'WiFi Calling\' είναι ενεργοποιημένο στη συσκευή σου)</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Ενεργοποίησέ το αν η συσκευή σου χρησιμοποιεί παράδοση SMS/MMS μέσω WiFi (ενεργοποίηση μόνο αν το \'WiFi Calling\' είναι ενεργοποιημένο στη συσκευή σου)</string>
   <string name="preferences_app_protection__blocked_contacts">Μπλοκαρισμένες επαφές</string>
   <string name="preferences_app_protection__safety_numbers_approval">Έγκριση αριθμών ασφαλείας</string>
   <string name="preferences_app_protecting__require_approval_of_new_safety_numbers_when_they_change">Να απαιτείται έγκριση των νέων αριθμών ασφαλείας όταν αλλάζουν</string>
@@ -1048,7 +1052,7 @@
   <!--conversation_list_batch-->
   <string name="conversation_list_batch__menu_delete_selected">Διαγραφή επιλεγμένων</string>
   <string name="conversation_list_batch__menu_select_all">Επιλογή όλων</string>
-  <string name="conversation_list_batch_archive__menu_archive_selected">Επιλεγμένο αρχείο</string>
+  <string name="conversation_list_batch_archive__menu_archive_selected">Αρχειοθέτηση επιλεγμένων</string>
   <string name="conversation_list_batch_unarchive__menu_unarchive_selected">Απαρχειοθέτηση επιλέχθηκε</string>
   <!--conversation_list-->
   <string name="conversation_list__menu_search">Αναζήτηση</string>
@@ -1103,7 +1107,7 @@
   </plurals>
   <string name="reminder_header_outdated_build_details_today">Η έκδοση του Signal σου θα λήξει σήμερα. Πάτα για να αναβαθμίσεις στην πιο πρόσφατη έκδοση.</string>
   <string name="reminder_header_expired_build">Η έκδοση του Signal σου έχει λήξει!</string>
-  <string name="reminder_header_expired_build_details">Τα μηνύματα δεν θα αποστέλλονται πια επιτυχώς. Πάτα για να αναβαθμίσεις στην πιο πρόσφατη έκδοση.</string>
+  <string name="reminder_header_expired_build_details">Τα μηνύματα δεν θα αποστέλλονται πλέον επιτυχώς. Πάτα για να αναβαθμίσεις στην πιο πρόσφατη έκδοση.</string>
   <string name="reminder_header_expired_build_button">ΑΝΑΒΑΘΜΙΣΗ</string>
   <string name="reminder_header_sms_default_title">Χρήση ως προκαθορισμένη εφαρμογή για τα SMS</string>
   <string name="reminder_header_sms_default_text">Πάτα για να κάνεις το Signal την προκαθορισμένη εφαρμογή για τα SMS.</string>

--- a/res/values-et/strings.xml
+++ b/res/values-et/strings.xml
@@ -362,6 +362,8 @@
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Vastuvõetud sõnum, mis on krüptitud kasutades vana, mittetoetatud Signali versiooni. Palun palu saatjal uuendada uusimale versioonile ja siis sõnum uuesti saata.</string>
   <string name="MessageRecord_left_group">Sa lahkusid grupist.</string>
+  <string name="MessageRecord_you_updated_group">Sa uuendasid gruppi.</string>
+  <string name="MessageRecord_s_updated_group">%s uuendas gruppi.</string>
   <string name="MessageRecord_s_called_you">%s helistas sulle</string>
   <string name="MessageRecord_called_s">Helistasid kontaktile %s</string>
   <string name="MessageRecord_missed_call_from">Vastamata kõne kontaktilt %s</string>
@@ -511,6 +513,7 @@
   <string name="SmsMessageRecord_secure_session_reset_s">%s lähtestas turvalise sessiooni.</string>
   <string name="SmsMessageRecord_duplicate_message">Duplikaatsõnum.</string>
   <!--ThreadRecord-->
+  <string name="ThreadRecord_group_updated">Grupp uuendatud</string>
   <string name="ThreadRecord_left_the_group">Lahkus grupist</string>
   <string name="ThreadRecord_secure_session_reset">Turvaline sessioon lähtestatud.</string>
   <string name="ThreadRecord_draft">Mustand:</string>
@@ -755,6 +758,7 @@
   <!--message_recipients_list_item-->
   <string name="message_recipients_list_item__verify">KINNITA</string>
   <string name="message_recipients_list_item__resend">SAADA UUESTI</string>
+  <string name="message_recipients_list_item__resending">Taassaatmine...</string>
   <!--GroupUtil-->
   <plurals name="GroupUtil_joined_the_group">
     <item quantity="one">%1$s liitus grupiga.</item>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -354,6 +354,8 @@ l\'importer à nouveau se traduira par des messages dupliqués.</string>
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Le message reçu est chiffré avec une ancienne version de Signal qui n\'est plus prise en charge. Veuillez demander à l’expéditeur de mettre à jour Signal et de renvoyer son message.</string>
   <string name="MessageRecord_left_group">Vous avez quitté le groupe.</string>
+  <string name="MessageRecord_you_updated_group">Vous avez mis à jour le groupe.</string>
+  <string name="MessageRecord_s_updated_group">%s a mis à jour le groupe.</string>
   <string name="MessageRecord_s_called_you">%s vous a appelé</string>
   <string name="MessageRecord_called_s">Appelé %s</string>
   <string name="MessageRecord_missed_call_from">Appel manqué de %s</string>
@@ -496,6 +498,7 @@ Réception d\'un message d\'échange de clés pour une version invalide du proto
   <string name="SmsMessageRecord_secure_session_reset_s">%s a réinitialisé la session sécurisée.</string>
   <string name="SmsMessageRecord_duplicate_message">Message doublon.</string>
   <!--ThreadRecord-->
+  <string name="ThreadRecord_group_updated">Groupe mis à jour</string>
   <string name="ThreadRecord_left_the_group">A quitté le groupe</string>
   <string name="ThreadRecord_secure_session_reset">Session sécurisée réinitialisée.</string>
   <string name="ThreadRecord_draft">Brouillon:</string>
@@ -740,6 +743,7 @@ Réception d\'un message d\'échange de clés pour une version invalide du proto
   <!--message_recipients_list_item-->
   <string name="message_recipients_list_item__verify">VÉRIFIER</string>
   <string name="message_recipients_list_item__resend">RÉENVOYER</string>
+  <string name="message_recipients_list_item__resending">Renvoyer...</string>
   <!--GroupUtil-->
   <plurals name="GroupUtil_joined_the_group">
     <item quantity="one">%1$s a rejoint le groupe.</item>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -253,6 +253,10 @@
   <string name="ExperienceUpgradeActivity_welcome_to_signal_excited">Dobro došli u Signal!</string>
   <string name="ExperienceUpgradeActivity_textsecure_is_now_signal">TextSecure je sada Signal.</string>
   <string name="ExperienceUpgradeActivity_textsecure_is_now_signal_long">TextSecure i RedPhone su sada jedna aplikacija: Signal. Pritisnite za pregled.</string>
+  <string name="ExperienceUpgradeActivity_say_hello_to_video_calls">Pozdravite sigurne video pozive.</string>
+  <string name="ExperienceUpgradeActivity_signal_now_supports_secure_video_calls">Signal sada podržava sigurne video pozive. Samo započnite Signal poziv kao i inače, pritisnite video tipku, i mahnite sugovorniku.</string>
+  <string name="ExperienceUpgradeActivity_signal_now_supports_secure_video_calling">Signal sada podržava sigurne video pozive.</string>
+  <string name="ExperienceUpgradeActivity_signal_now_supports_secure_video_calling_long">Signal sada podržava sigurne video pozive. Pritisnite kako biste istražili.</string>
   <!--ExportFragment-->
   <string name="ExportFragment_export">Izvoz</string>
   <string name="ExportFragment_export_plaintext_to_storage">Izvezi u obliku običnog teksta na disk?</string>
@@ -373,6 +377,8 @@ ponovno uvoženje će rezultirati duplim porukama.</string>
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Primljena je poruka kriptirana starom inačicom Signal aplikacije koja više nije podržana. Molimo zapitajte pošiljatelja da ažurira na najnoviju inačicu aplikacije i ponovno pošalje poruku.</string>
   <string name="MessageRecord_left_group">Napustili ste grupu.</string>
+  <string name="MessageRecord_you_updated_group">Ažurirali ste grupu.</string>
+  <string name="MessageRecord_s_updated_group">%s je ažurirao grupu.</string>
   <string name="MessageRecord_s_called_you">%s vas je zvao</string>
   <string name="MessageRecord_called_s">Nazvao %s</string>
   <string name="MessageRecord_missed_call_from">Propušteni poziv od %s</string>
@@ -516,6 +522,7 @@ Primljena poruka razmjene ključeva za pogrešnu inačicu protokola.</string>
   <string name="SmsMessageRecord_secure_session_reset_s">%s resetiranje sigurne sesije.</string>
   <string name="SmsMessageRecord_duplicate_message">Dupla poruka.</string>
   <!--ThreadRecord-->
+  <string name="ThreadRecord_group_updated">Grupa je ažurirana</string>
   <string name="ThreadRecord_left_the_group">Napustio/la grupu</string>
   <string name="ThreadRecord_secure_session_reset">Resetiranje sigurne sesije.</string>
   <string name="ThreadRecord_draft">Skica:</string>
@@ -527,6 +534,8 @@ Primljena poruka razmjene ključeva za pogrešnu inačicu protokola.</string>
   <string name="ThreadRecord_disappearing_message_time_updated_to_s">Vrijeme nestajanja poruke postavljeno na %s</string>
   <string name="ThreadRecord_your_safety_number_with_s_has_changed">Vaš sigurnosni broj s %s je izmjenjen.</string>
   <!--UpdateApkReadyListener-->
+  <string name="UpdateApkReadyListener_Signal_update">Signal ažuriranje</string>
+  <string name="UpdateApkReadyListener_a_new_version_of_signal_is_available_tap_to_update">Nova inačica Signala je dostupna, pritisnite za ažuriranje</string>
   <!--VerifyIdentityActivity-->
   <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">Vaš kontakt koristi stariju Signal inačicu. Zamolite ih da ažuriraju Signal prije provjere sigurnosnog broja.</string>
   <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">Vaš kontakt koristi noviju Signal inačicu s nekompatibilnim QR kod oblikom. Ažurirajte vašu inačicu kako biste usporedili.</string>
@@ -764,6 +773,7 @@ Uvezi nekriptiranu kopiju. Kompatibilno s \'SMSBackup And Restore\'.</string>
   <!--message_recipients_list_item-->
   <string name="message_recipients_list_item__verify">POTVRDI</string>
   <string name="message_recipients_list_item__resend">PONOVNO POŠALJI</string>
+  <string name="message_recipients_list_item__resending">Ponovno slanje...</string>
   <!--GroupUtil-->
   <plurals name="GroupUtil_joined_the_group">
     <item quantity="one">%1$s se pridružio grupi.</item>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -363,6 +363,8 @@ akkor az újbóli importálás duplikált üzeneteket eredményez.</string>
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Egy üzenet érkezett a Signal egy régebbi verziójával titkosítva, ami már nem támogatott. Kérlek kérd meg a küldőt, hogy frissítsen a legfrissebb verzióra és küldje újra az üzenetet.</string>
   <string name="MessageRecord_left_group">Elhagytad a csoportot.</string>
+  <string name="MessageRecord_you_updated_group">Frissítetted a csoportot.</string>
+  <string name="MessageRecord_s_updated_group">%s frissítette a csoportot.</string>
   <string name="MessageRecord_s_called_you">%s hívott téged</string>
   <string name="MessageRecord_called_s">Hívtad: %s</string>
   <string name="MessageRecord_missed_call_from">Nem fogadott hívás tőle: %s</string>
@@ -512,6 +514,7 @@ Kulcs-csere üzenet érkezett érvénytelen protokoll verzióhoz.
   <string name="SmsMessageRecord_secure_session_reset_s">%s alaphelyzetbe állította a biztonságos munkamenetet.</string>
   <string name="SmsMessageRecord_duplicate_message">Üzenet duplikálása.</string>
   <!--ThreadRecord-->
+  <string name="ThreadRecord_group_updated">Csoport frissítve</string>
   <string name="ThreadRecord_left_the_group">Elhagyta a csoportot</string>
   <string name="ThreadRecord_secure_session_reset">Biztonságos munkamenet alaphelyzetbe állítása.</string>
   <string name="ThreadRecord_draft">Piszkozat:</string>
@@ -758,6 +761,7 @@ Kulcs-csere üzenet érkezett érvénytelen protokoll verzióhoz.
   <!--message_recipients_list_item-->
   <string name="message_recipients_list_item__verify">ELLENŐRZÉS</string>
   <string name="message_recipients_list_item__resend">ÚJRAKÜLDÉS</string>
+  <string name="message_recipients_list_item__resending">Újraküldés...</string>
   <!--GroupUtil-->
   <plurals name="GroupUtil_joined_the_group">
     <item quantity="one">%1$s csatlakozott a csoporthoz.</item>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -132,6 +132,10 @@
   <string name="ConversationActivity_error_sending_voice_message">שגיאה בשליחת הודעה קולית</string>
   <string name="ConversationActivity_there_is_no_app_available_to_handle_this_link_on_your_device">אין אפליקציה זמינה לטיפול בקישור כזה במכשיר שלך.</string>
   <!--ConversationAdapter-->
+  <plurals name="ConversationAdapter_n_unread_messages">
+    <item quantity="one">מסר %d לא נקרא</item>
+    <item quantity="other">%d מסרים לא נקראו</item>
+  </plurals>
   <!--ConversationFragment-->
   <string name="ConversationFragment_message_details">פרטי מסר</string>
   <string name="ConversationFragment_transport_s_sent_received_s">תעבורה: %1$s\nנשלח/התקבל: %2$s</string>
@@ -334,8 +338,11 @@
   <string name="MessageDetailsRecipient_new_safety_number">מספר בטיחות חדש</string>
   <!--MessageRetrievalService-->
   <string name="MessageRetrievalService_signal">סיגנל</string>
+  <string name="MessageRetrievalService_background_connection_enabled">חיבור רקע מופעל</string>
   <!--MmsDownloader-->
   <string name="MmsDownloader_error_storing_mms">שגיאה באחסון ה־MMS!</string>
+  <string name="MmsDownloader_error_connecting_to_mms_provider">שגיאה בהתחברות לספק MMS</string>
+  <string name="MmsDownloader_error_reading_mms_settings">שגיאה בקריאת הגדרות MMS של ספק התקשורת האלחוטית</string>
   <!--- NotificationBarManager-->
   <string name="NotificationBarManager_signal_call_in_progress">שיחת סיגנל נערכת עכשיו</string>
   <string name="NotificationBarManager_missed_call_from_s">שיחה שלא נענתה מאת %s</string>
@@ -348,9 +355,13 @@
   <string name="NotificationBarManager__cancel_call">לבטל את השיחה</string>
   <!--NotificationMmsMessageRecord-->
   <string name="NotificationMmsMessageRecord_multimedia_message">מסר מולטימדיה</string>
+  <string name="NotificationMmsMessageRecord_downloading_mms_message">הורדת מסר MMS</string>
+  <string name="NotificationMmsMessageRecord_error_downloading_mms_message">שגיאה בהורדת מסר MMS, נא ללחוץ לניסיון חוזר</string>
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">לא ניתן יותר לקבל מסר שהוצפן בגרסה ישנה של סיגנל. נא לבקש ממי ששלח אותו לשדרג לגרסה החדשה ביותר של סיגנל ולשלוח את המסר שוב.</string>
   <string name="MessageRecord_left_group">עזבת את הקבוצה.</string>
+  <string name="MessageRecord_you_updated_group">עדכנת את הקבוצה.</string>
+  <string name="MessageRecord_s_updated_group">%s עדכן את הקבוצה</string>
   <string name="MessageRecord_s_called_you">הייתה לך שיחה מאת %s</string>
   <string name="MessageRecord_called_s">התקשרת אל %s</string>
   <string name="MessageRecord_missed_call_from">שיחה שלא נענתה מאת %s</string>
@@ -377,6 +388,7 @@
   <string name="DeviceProvisioningActivity_content_progress_no_device">לא נמצא מכשיר.</string>
   <string name="DeviceProvisioningActivity_content_progress_network_error">שגיאת רשת.</string>
   <string name="DeviceProvisioningActivity_content_progress_key_error">קוד QR בלתי־תקין.</string>
+  <string name="DeviceProvisioningActivity_sorry_you_have_too_many_devices_linked_already">סליחה, חיברת יותר מדי מכשירים, נא לנסות להסיר כמה.</string>
   <string name="DeviceActivity_sorry_this_is_not_a_valid_device_link_qr_code">סליחה, זה לא קוד QR תקין לקישור מכשיר.</string>
   <string name="DeviceProvisioningActivity_link_a_signal_device">לקשר מכשיר סיגנל?</string>
   <string name="DeviceProvisioningActivity_it_looks_like_youre_trying_to_link_a_signal_device_using_a_3rd_party_scanner">נראה שניסית לקשר מכשיר סיגנל באמצעות סורק מצד שלישי. למען בטיחותך, נא לסרוק את הקוד שוב באמצעות סיגנל.</string>
@@ -407,7 +419,9 @@
   <string name="RecipientPreferenceActivity_unblock">הסרת חסימה</string>
   <string name="RecipientPreferenceActivity_enabled">מופעל</string>
   <string name="RecipientPreferenceActivity_disabled">כבוי</string>
+  <string name="RecipientPreferenceActivity_available_once_a_message_has_been_sent_or_received">זמין אחרי שמסר נשלח או התקבל.</string>
   <!--RecipientProvider-->
+  <string name="RecipientProvider_unnamed_group">קבוצה ללא שם</string>
   <!--RedPhone-->
   <string name="RedPhone_answering">עונה</string>
   <string name="RedPhone_ending_call">מסיים את השיחה</string>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -9,10 +9,20 @@
   <string name="AbstractNotificationBuilder_new_message">Nauja žinutė</string>
   <!--ApplicationPreferencesActivity-->
   <string name="ApplicationPreferencesActivity_currently_s">Šiuo metu: %s</string>
-  <string name="ApplicationPreferenceActivity_you_havent_set_a_passphrase_yet">Jūs dar nepasirinkote slaptos frazės!</string>
-  <string name="ApplicationPreferencesActivity_delete_all_old_messages_now">Dabar ištrinti visas senas žinutes?</string>
+  <string name="ApplicationPreferenceActivity_you_havent_set_a_passphrase_yet">Jūs dar nesate nustatę slaptafrazės!</string>
+  <plurals name="ApplicationPreferencesActivity_messages_per_conversation">
+    <item quantity="one">%d žinutė pokalbyje</item>
+    <item quantity="few">%d žinutės pokalbyje</item>
+    <item quantity="other">%d žinučių pokalbyje</item>
+  </plurals>
+  <string name="ApplicationPreferencesActivity_delete_all_old_messages_now">Ištrinti visas senas žinutes dabar?</string>
+  <plurals name="ApplicationPreferencesActivity_this_will_immediately_trim_all_conversations_to_the_d_most_recent_messages">
+    <item quantity="one">Tai nedelsiant apkirps visus pokalbius iki %d naujausios žinutės.</item>
+    <item quantity="few">Tai nedelsiant apkirps visus pokalbius iki %d naujausių žinučių.</item>
+    <item quantity="other">Tai nedelsiant apkirps visus pokalbius iki %d naujausių žinučių.</item>
+  </plurals>
   <string name="ApplicationPreferencesActivity_delete">Ištrinti</string>
-  <string name="ApplicationPreferencesActivity_disable_passphrase">Išjungti slaptą frazę?</string>
+  <string name="ApplicationPreferencesActivity_disable_passphrase">Išjungti slaptafrazę?</string>
   <string name="ApplicationPreferencesActivity_this_will_permanently_unlock_signal_and_message_notifications">Tai visiems laikams atrakins Signal ir žinučių pranešimus.</string>
   <string name="ApplicationPreferencesActivity_disable">Išjungti</string>
   <string name="ApplicationPreferencesActivity_unregistering">Išregistruojama</string>
@@ -33,7 +43,7 @@
   <string name="ApplicationPreferencesActivity_appearance_summary">Tema %1$s, Kalba %2$s</string>
   <!--AppProtectionPreferenceFragment-->
   <plurals name="AppProtectionPreferenceFragment_minutes">
-    <item quantity="one">1 minutė</item>
+    <item quantity="one">%d minutė</item>
     <item quantity="few">%d minutės</item>
     <item quantity="other">%d minučių</item>
   </plurals>
@@ -65,7 +75,7 @@
   <string name="ContactsDatabase_signal_call_s">Signal skambutis %s</string>
   <!--ConversationItem-->
   <string name="ConversationItem_message_size_d_kb">Žinutės dydis: %d KB</string>
-  <string name="ConversationItem_expires_s">Dings po %s</string>
+  <string name="ConversationItem_expires_s">Nustoja galioti: %s</string>
   <string name="ConversationItem_error_not_delivered">Nepristatyta</string>
   <string name="ConversationItem_view_secure_media_question">Žiūrėti saugią mediją?</string>
   <string name="ConversationItem_this_media_has_been_stored_in_an_encrypted_database_external_viewer_warning">Ši medija buvo laikoma užšifruotoje duomenų bazėje. Deja, šiuo metu norint ją peržiūrėti naudojant išorinę turinio žiūryklę, reikia duomenis laikinai iššifruoti ir įrašyti į atmintį. Ar tikrai norėtumėte tai padaryti?</string>
@@ -73,6 +83,7 @@
   <string name="ConversationItem_received_key_exchange_message_tap_to_process">Gauta šifro apsikeitimo žinutė, bakstelėkite norėdami tęsti.</string>
   <string name="ConversationItem_group_action_left">%1$s išėjo iš grupės.</string>
   <string name="ConversationItem_click_for_details">Bakstelėkite išsamesnei informacijai</string>
+  <string name="ConversationItem_click_to_approve_unencrypted">Bakstelėkite, norėdami sugrįžti prie nesaugaus surogato</string>
   <string name="ConversationItem_click_to_approve_unencrypted_sms_dialog_title">Sugrįžti prie nešifruotų SMS naudojimo?</string>
   <string name="ConversationItem_click_to_approve_unencrypted_mms_dialog_title">Sugrįžti prie nešifruotų MMS naudojimo?</string>
   <string name="ConversationItem_click_to_approve_unencrypted_dialog_message">Ši žinutė <b>nebus</b> užšifruota, nes gavėjas daugiau nebėra Signal naudotojas.\n\nSiųsti neapsaugotą žinutę?</string>
@@ -86,7 +97,7 @@
   <string name="ConversationActivity_delete_thread_question">Ištrinti pokalbį?</string>
   <string name="ConversationActivity_this_will_permanently_delete_all_messages_in_this_conversation">Tai visiems laikams ištrins visas šiame pokalbyje esančias žinutes.</string>
   <string name="ConversationActivity_add_attachment">Pridėti priedą</string>
-  <string name="ConversationActivity_select_contact_info">Pasirinkti kontakto info</string>
+  <string name="ConversationActivity_select_contact_info">Pasirinkti kontakto informaciją</string>
   <string name="ConversationActivity_compose_message">Rašyti žinutę</string>
   <string name="ConversationActivity_sorry_there_was_an_error_setting_your_attachment">Apgailestaujame, pridedant priedą, įvyko klaida.</string>
   <string name="ConversationActivity_the_gif_you_selected_was_too_big">Jūsų pasirinktas gif buvo per didelis!</string>
@@ -94,8 +105,13 @@
   <string name="ConversationActivity_sorry_the_selected_audio_exceeds_message_size_restrictions">Atleiskite, pasirinktas garso įrašas viršija leidžiamą žinutės dydį (%1$skB).</string>
   <string name="ConversationActivity_recipient_is_not_a_valid_sms_or_email_address_exclamation">Gavėjas nėra tinkamas SMS ar el. pašto adresas!</string>
   <string name="ConversationActivity_message_is_empty_exclamation">Žinutė tuščia!</string>
-  <string name="ConversationActivity_group_members">Grupės nariai</string>
+  <string name="ConversationActivity_group_members">Grupės dalyviai</string>
   <string name="ConversationActivity_group_conversation">Grupės pokalbis</string>
+  <plurals name="ConversationActivity_d_recipients_in_group">
+    <item quantity="one">%d dalyvis</item>
+    <item quantity="few">%d dalyviai</item>
+    <item quantity="other">%d dalyvių</item>
+  </plurals>
   <string name="ConversationActivity_saved_draft">Juodraštis įrašytas</string>
   <string name="ConversationActivity_invalid_recipient">Neteisingas gavėjas!</string>
   <string name="ConversationActivity_calls_not_supported">Skambučiai nepalaikomi</string>
@@ -109,6 +125,7 @@
   <string name="ConversationActivity_lets_use_this_to_chat">Naudokime pokalbiui štai ką: %1$s</string>
   <string name="ConversationActivity_error_leaving_group">Klaida, išeinant iš grupės</string>
   <string name="ConversationActivity_mms_not_supported_title">MMS nepalaikoma</string>
+  <string name="ConversationActivity_mms_not_supported_message">Ši žinutė negali būti išsiųsta, kadangi jūsų tiekėjas nepalaiko MMS.</string>
   <string name="ConversationActivity_specify_recipient">Prašome pasirinkti kontaktą</string>
   <string name="ConversationActivity_unblock_this_contact_question">Atblokuoti šį kontaktą?</string>
   <string name="ConversationActivity_you_will_once_again_be_able_to_receive_messages_and_calls_from_this_contact">Jūs ir vėl galėsite gauti žinutes ir priimti skambučius nuo šio kontakto.</string>
@@ -119,14 +136,31 @@
   <string name="ConversationActivity_error_sending_voice_message">Klaida, išsiunčiant balso žinutę</string>
   <string name="ConversationActivity_there_is_no_app_available_to_handle_this_link_on_your_device">Nėra prieinamos programėlės, kuri galėtų apdoroti šią nuorodą jūsų įrenginyje.</string>
   <!--ConversationAdapter-->
+  <plurals name="ConversationAdapter_n_unread_messages">
+    <item quantity="one">%d neskaityta žinutė</item>
+    <item quantity="few">%d neskaitytos žinutės</item>
+    <item quantity="other">%d neskaitytų žinučių</item>
+  </plurals>
   <!--ConversationFragment-->
   <string name="ConversationFragment_message_details">Žinutės informacija</string>
+  <string name="ConversationFragment_transport_s_sent_received_s">Perdavimas: %1$s\nIšsiųsta/Gauta: %2$s</string>
+  <string name="ConversationFragment_sender_s_transport_s_sent_s_received_s">Siuntėjas: %1$s\nPerdavimas: %2$s\nIšsiųsta: %3$s\nGauta: %4$s</string>
   <plurals name="ConversationFragment_delete_selected_messages">
     <item quantity="one">Ištrinti pažymėtą žinutę?</item>
     <item quantity="few">Ištrinti pažymėtas žinutes?</item>
     <item quantity="other">Ištrinti pažymėtas žinutes?</item>
   </plurals>
+  <plurals name="ConversationFragment_this_will_permanently_delete_all_n_selected_messages">
+    <item quantity="one">Tai visiems laikams ištrins %1$d pasirinktą žinutę.</item>
+    <item quantity="few">Tai visiems laikams ištrins visas %1$d pasirinktas žinutes.</item>
+    <item quantity="other">Tai visiems laikams ištrins visas %1$d pasirinktų žinučių.</item>
+  </plurals>
   <string name="ConversationFragment_save_to_sd_card">Įrašyti į atmintį?</string>
+  <plurals name="ConversationFragment_saving_n_media_to_storage_warning">
+    <item quantity="one">Šios %1$d medijos įrašymas į atmintį leis bet kuriai programėlei jūsų įrenginyje prieigą prie jos.\n\nTęsti?</item>
+    <item quantity="few">Šių visų %1$d medijų įrašymas į atmintį leis bet kuriai programėlei jūsų įrenginyje prieigą prie jų.\n\nTęsti?</item>
+    <item quantity="other">Šių visų %1$d medijų įrašymas į atmintį leis bet kuriai programėlei jūsų įrenginyje prieigą prie jų.\n\nTęsti?</item>
+  </plurals>
   <plurals name="ConversationFragment_error_while_saving_attachments_to_sd_card">
     <item quantity="one">Klaida, įrašant priedą į atmintį!</item>
     <item quantity="few">Klaida, įrašant priedus į atmintį!</item>
@@ -139,9 +173,14 @@
   </plurals>
   <string name="ConversationFragment_unable_to_write_to_sd_card_exclamation">Nepavyksta įrašyti į atmintį!</string>
   <plurals name="ConversationFragment_saving_n_attachments">
-    <item quantity="one">Įrašomas priedas</item>
+    <item quantity="one">Įrašomas %1$d priedas</item>
     <item quantity="few">Įrašomi %1$d priedai</item>
     <item quantity="other">Įrašoma %1$d priedų</item>
+  </plurals>
+  <plurals name="ConversationFragment_saving_n_attachments_to_sd_card">
+    <item quantity="one">Įrašomas į atmintį %1$d priedas...</item>
+    <item quantity="few">Įrašomi į atmintį %1$d priedai...</item>
+    <item quantity="other">Įrašoma į atmintį %1$d priedų...</item>
   </plurals>
   <string name="ConversationFragment_collecting_attahments">Renkami priedai...</string>
   <string name="ConversationFragment_pending">Laukiama...</string>
@@ -154,9 +193,29 @@
   <string name="ConversationListActivity_search">Ieškoti</string>
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Jūsų įrenginyje nėra įdiegtos naršyklės.</string>
   <!--ConversationListFragment-->
+  <plurals name="ConversationListFragment_delete_selected_conversations">
+    <item quantity="one">Ištrinti pasirinktą pokalbį?</item>
+    <item quantity="few">Ištrinti pasirinktus pokalbius?</item>
+    <item quantity="other">Ištrinti pasirinktus pokalbius?</item>
+  </plurals>
+  <plurals name="ConversationListFragment_this_will_permanently_delete_all_n_selected_conversations">
+    <item quantity="one">Tai visiems laikams ištrins %1$d pasirinktą pokalbį.</item>
+    <item quantity="few">Tai visiems laikams ištrins visus %1$d pasirinktus pokalbius.</item>
+    <item quantity="other">Tai visiems laikams ištrins visus %1$d pasirinktų pokalbių.</item>
+  </plurals>
   <string name="ConversationListFragment_deleting">Ištrinama</string>
-  <string name="ConversationListFragment_deleting_selected_conversations">Trinami pasirinkti pokalbiai…</string>
+  <string name="ConversationListFragment_deleting_selected_conversations">Ištrinami pasirinkti pokalbiai…</string>
+  <plurals name="ConversationListFragment_conversations_archived">
+    <item quantity="one">Užarchyvuotas %d pokalbis</item>
+    <item quantity="few">Užarchyvuoti %d pokalbiai</item>
+    <item quantity="other">Užarchyvuota %d pokalbių</item>
+  </plurals>
   <string name="ConversationListFragment_undo">ATŠAUKTI</string>
+  <plurals name="ConversationListFragment_moved_conversations_to_inbox">
+    <item quantity="one">%d pokalbis perkeltas į gautųjų aplanką</item>
+    <item quantity="few">%d pokalbiai perkelti į gautųjų aplanką</item>
+    <item quantity="other">%d pokalbių perkelta į gautųjų aplanką</item>
+  </plurals>
   <!--ConversationListItem-->
   <string name="ConversationListItem_key_exchange_message">Šifro apsikeitimo žinutė</string>
   <!--ConversationListItemAction-->
@@ -174,7 +233,7 @@
   <string name="DeviceListActivity_unlink_s">Atsieti \"%s\"?</string>
   <string name="DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive">Atsiejus šį įrenginį, jis daugiau nebegalės siųsti ar gauti žinučių.</string>
   <string name="DeviceListActivity_network_connection_failed">Tinklo ryšys patyrė nesėkmę</string>
-  <string name="DeviceListActivity_try_again">Bandyk dar kart</string>
+  <string name="DeviceListActivity_try_again">Bandykite dar kartą</string>
   <string name="DeviceListActivity_unlinking_device">Atsiejamas įrenginys...</string>
   <string name="DeviceListActivity_unlinking_device_no_ellipsis">Atsiejamas įrenginys</string>
   <string name="DeviceListActivity_network_failed">Tinklas patyrė nesėkmę!</string>
@@ -184,6 +243,8 @@
   <string name="DeviceListItem_last_active_s">Paskutinį kartą aktyvus %s</string>
   <string name="DeviceListItem_today">Šiandien</string>
   <!--DozeReminder-->
+  <string name="DozeReminder_optimize_for_missing_play_services">Optimizuoti trūkstamoms „Play“ paslaugoms</string>
+  <string name="DozeReminder_this_device_does_not_support_play_services_tap_to_disable_system_battery">Šis įrenginys nepalaiko „Play“ paslaugų. Bakstelėkite, norėdami išjungti sistemos baterijos optimizavimus, kurie neleidžia Signal gauti žinučių tol, kol įrenginys yra neaktyvus.</string>
   <!--ShareActivity-->
   <string name="ShareActivity_share_with">Dalintis su</string>
   <!--ExperienceUpgradeActivity-->
@@ -192,6 +253,10 @@
   <string name="ExperienceUpgradeActivity_welcome_to_signal_excited">Sveiki atvykę į Signal!</string>
   <string name="ExperienceUpgradeActivity_textsecure_is_now_signal">TextSecure dabar tapo Signal.</string>
   <string name="ExperienceUpgradeActivity_textsecure_is_now_signal_long">TextSecure ir RedPhone dabar yra viena programėlė: Signal. Bakstelėkite, norėdami sužinoti daugiau.</string>
+  <string name="ExperienceUpgradeActivity_say_hello_to_video_calls">Pasveikinkite saugius vaizdo skambučius.</string>
+  <string name="ExperienceUpgradeActivity_signal_now_supports_secure_video_calls">Dabar, Signal palaiko saugius vaizdo skambučius. Tiesiog, pradėkite, kaip įprasta, Signal skambutį, bakstelėkite vaizdo mygtuką ir pamojuokite.</string>
+  <string name="ExperienceUpgradeActivity_signal_now_supports_secure_video_calling">Dabar, Signal palaiko saugius vaizdo skambučius.</string>
+  <string name="ExperienceUpgradeActivity_signal_now_supports_secure_video_calling_long">Dabar, Signal palaiko saugius vaizdo skambučius. Bakstelėkite, norėdami išnagrinėti.</string>
   <!--ExportFragment-->
   <string name="ExportFragment_export">Eksportuoti</string>
   <string name="ExportFragment_export_plaintext_to_storage">Eksportuoti grynąjį tekstą į atmintį?</string>
@@ -204,7 +269,7 @@
   <string name="ExportFragment_export_successful">Eksportavimas sėkmingas.</string>
   <!--GcmRefreshJob-->
   <string name="GcmRefreshJob_Permanent_Signal_communication_failure">Ilgalaikė Signal susisiekimo triktis!</string>
-  <string name="GcmRefreshJob_Signal_was_unable_to_register_with_Google_Play_Services">Signal negalėjo būti užregistruotas su „Google Play Services“. Signal žinutės ir skambučiai buvo išjungti, prašome pabandyti iš naujo registruotis nustatymų sekcijoje.</string>
+  <string name="GcmRefreshJob_Signal_was_unable_to_register_with_Google_Play_Services">Signal nepavyko prisiregistruoti prie „Google Play“ paslaugų. Signal žinutės ir skambučiai buvo išjungti, prašome pabandyti iš naujo registruotis skyrelyje Nustatymai (angl. Settings) &gt; Išplėstiniai (angl. Advanced).</string>
   <!--GiphyActivity-->
   <string name="GiphyActivity_error_while_retrieving_full_resolution_gif">Klaida, gaunant pilnos raiškos GIF</string>
   <!--GiphyFragmentPageAdapter-->
@@ -212,12 +277,16 @@
   <string name="GiphyFragmentPagerAdapter_stickers">Paveiksliukai</string>
   <!--GroupCreateActivity-->
   <string name="GroupCreateActivity_actionbar_title">Nauja grupė</string>
+  <string name="GroupCreateActivity_actionbar_edit_title">Taisyti grupę</string>
   <string name="GroupCreateActivity_group_name_hint">Grupės pavadinimas</string>
   <string name="GroupCreateActivity_actionbar_mms_title">Nauja MMS grupė</string>
   <string name="GroupCreateActivity_contacts_dont_support_push">Jūs pasirinkote kontaktą, kuris nepalaiko Signal grupes, taigi, ši grupė bus MMS.</string>
+  <string name="GroupCreateActivity_youre_not_registered_for_signal">Jūs nesate užsiregistravę Signal žinutėms ir skambučiams, taigi, Signal grupės yra išjungtos. Prašome pabandyti registruotis skyrelyje Nustatymai (angl. Settings) &gt; Išplėstiniai (angl. Advanced).</string>
   <string name="GroupCreateActivity_contacts_mms_exception">Įvyko netikėta klaida, kuri privertė grupės kūrimą patirti nesėkmę.</string>
-  <string name="GroupCreateActivity_contacts_no_members">Tau reikia bent vieno žmogaus grupėje!</string>
+  <string name="GroupCreateActivity_contacts_no_members">Jums jūsų grupėje reikalingas bent vienas žmogus!</string>
+  <string name="GroupCreateActivity_contacts_invalid_number">Vieno iš jūsų grupės dalyvių numerį nepavyksta perskaityti teisingai. Prašome tai ištaisyti arba pašalinti tą kontaktą ir bandyti dar kartą.</string>
   <string name="GroupCreateActivity_avatar_content_description">Grupės avataras</string>
+  <string name="GroupCreateActivity_menu_apply_button">Taikyti</string>
   <string name="GroupCreateActivity_creating_group">Kuriama %1$s…</string>
   <string name="GroupCreateActivity_updating_group">Atnaujinama %1$s...</string>
   <string name="GroupCreateActivity_cannot_add_non_push_to_existing_group">Nepavyko pridėti %1$s, kadangi tai nėra Signal naudotojas.</string>
@@ -267,8 +336,18 @@
   <string name="InviteActivity_heart_content_description">Širdis</string>
   <string name="InviteActivity_invitations_sent">Pakvietimai išsiųsti!</string>
   <string name="InviteActivity_invite_to_signal">Pakviesti į Signal</string>
+  <plurals name="InviteActivity_send_sms_to_friends">
+    <item quantity="one">SIŲSTI SMS %d DRAUGUI</item>
+    <item quantity="few">SIŲSTI SMS %d DRAUGAMS</item>
+    <item quantity="other">SIŲSTI SMS %d DRAUGŲ</item>
+  </plurals>
+  <plurals name="InviteActivity_send_sms_invites">
+    <item quantity="one">Siųsti %d SMS pakvietimą?</item>
+    <item quantity="few">Siųsti %d SMS pakvietimus?</item>
+    <item quantity="other">Siųsti %d SMS pakvietimų?</item>
+  </plurals>
   <string name="InviteActivity_lets_switch_to_signal">Persijunkime į Signal: %1$s</string>
-  <string name="InviteActivity_no_app_to_share_to">Nėra programos, kuri galėtų būti naudojama dalijinimuosi.</string>
+  <string name="InviteActivity_no_app_to_share_to">Atrodo, kad neturite programėlių su kuriomis dalintis.</string>
   <string name="InviteActivity_friends_dont_let_friends_text_unencrypted">Draugai neleidžia draugams kalbėtis nešifruotai.</string>
   <!--KeyScanningActivity-->
   <string name="KeyScanningActivity_no_scanned_key_found_exclamation">Nerasta skenuotų raktų!</string>
@@ -279,9 +358,11 @@
   <string name="MessageDetailsRecipient_new_safety_number">Naujas saugumo numeris</string>
   <!--MessageRetrievalService-->
   <string name="MessageRetrievalService_signal">Signal</string>
+  <string name="MessageRetrievalService_background_connection_enabled">Foninis ryšys įjungtas</string>
   <!--MmsDownloader-->
-  <string name="MmsDownloader_error_storing_mms">Nepavyko kaupti MMS!</string>
-  <string name="MmsDownloader_error_connecting_to_mms_provider">Nepavyko prisijungti prie MMS tinklo</string>
+  <string name="MmsDownloader_error_storing_mms">Klaida, talpinant MMS!</string>
+  <string name="MmsDownloader_error_connecting_to_mms_provider">Nepavyko prisijungti prie MMS tiekėjo</string>
+  <string name="MmsDownloader_error_reading_mms_settings">Klaida, skaitant belaidžio tiekėjo MMS nustatymus</string>
   <!--- NotificationBarManager-->
   <string name="NotificationBarManager_signal_call_in_progress">Signal skambutis yra eigoje</string>
   <string name="NotificationBarManager_missed_call_from_s">Praleistas skambutis nuo %s</string>
@@ -291,7 +372,7 @@
   <string name="NotificationBarManager__deny_call">Atmesti skambutį</string>
   <string name="NotificationBarManager__answer_call">Atsiliepti į skambutį</string>
   <string name="NotificationBarManager__end_call">Baigti skambutį</string>
-  <string name="NotificationBarManager__cancel_call">Atmesti skambutį</string>
+  <string name="NotificationBarManager__cancel_call">Atsisakyti skambučio</string>
   <!--NotificationMmsMessageRecord-->
   <string name="NotificationMmsMessageRecord_multimedia_message">Multimedijos žinutė</string>
   <string name="NotificationMmsMessageRecord_downloading_mms_message">Atsiunčiama MMS žinutė</string>
@@ -299,10 +380,12 @@
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Gauta žinutė buvo užšifruota, naudojant seną Signal versiją, kuri daugiau nebepalaikoma. Paprašykite siuntėjo atnaujinti savo programėlę į naujausią versiją ir iš naujo išsiųsti žinutę.</string>
   <string name="MessageRecord_left_group">Jūs išėjote iš grupės.</string>
-  <string name="MessageRecord_s_called_you">%s tau paskambino.</string>
-  <string name="MessageRecord_called_s">Paskambino %s</string>
+  <string name="MessageRecord_you_updated_group">Jūs atnaujinote grupę.</string>
+  <string name="MessageRecord_s_updated_group">%s atnaujino grupę.</string>
+  <string name="MessageRecord_s_called_you">Jums skambino %s</string>
+  <string name="MessageRecord_called_s">Skambino %s</string>
   <string name="MessageRecord_missed_call_from">Praleistas skambutis nuo %s</string>
-  <string name="MessageRecord_s_is_on_signal_say_hey">%s naudoja Signal, sakyk labas!</string>
+  <string name="MessageRecord_s_is_on_signal_say_hey">%s naudoja Signal, pasisveikinkite!</string>
   <string name="MessageRecord_you_set_disappearing_message_time_to_s">Jūs nustatėte išnykstančių žinučių laiką į %1$s.</string>
   <string name="MessageRecord_s_set_disappearing_message_time_to_s">%1$s nustatė išnykstančių žinučių laiką į %2$s.</string>
   <string name="MessageRecord_your_safety_number_with_s_has_changed">Jūsų saugumo numeris su %s pasikeitė.</string>
@@ -335,12 +418,12 @@
   <string name="ExpirationDialog_your_messages_will_not_expire">Jūsų žinučių galiojimas nesibaigs.</string>
   <string name="ExpirationDialog_your_messages_will_disappear_s_after_they_have_been_seen">Šiame pokalbyje išsiųstos ir gautos žinutės išnyks %s po to, kai jos buvo pamatytos.</string>
   <!--PassphrasePromptActivity-->
-  <string name="PassphrasePromptActivity_enter_passphrase">Įvesti slaptą frazę</string>
+  <string name="PassphrasePromptActivity_enter_passphrase">Įveskite slaptafrazę</string>
   <string name="PassphrasePromptActivity_watermark_content_description">Signal piktograma</string>
   <string name="PassphrasePromptActivity_ok_button_content_description">Pateikti slaptafrazę</string>
   <string name="PassphrasePromptActivity_invalid_passphrase_exclamation">Neteisinga slaptafrazė!</string>
   <!--PlayServicesProblemFragment-->
-  <string name="PlayServicesProblemFragment_the_version_of_google_play_services_you_have_installed_is_not_functioning">Prašome iš naujo įdiegti „Google Play Services“ – jūsų turima versija tinkamai neveikia.</string>
+  <string name="PlayServicesProblemFragment_the_version_of_google_play_services_you_have_installed_is_not_functioning">Jūsų turima įdiegta „Google Play“ paslaugų versija nefunkcionuoja tinkamai. Prašome iš naujo įdiegti „Google Play“ paslaugas ir bandyti dar kartą.</string>
   <!--RatingManager-->
   <string name="RatingManager_rate_this_app">Įvertinkite šią programėlę</string>
   <string name="RatingManager_if_you_enjoy_using_this_app_please_take_a_moment">Jeigu jūs mėgaujatės naudodamiesi šia programėle, skirkite minutėlę mums padėti ir įvertinkite ją.</string>
@@ -364,7 +447,7 @@
   <string name="RedPhone_answering">Atsiliepiama</string>
   <string name="RedPhone_ending_call">Baigiamas skambutis</string>
   <string name="RedPhone_dialing">Renkamas numeris</string>
-  <string name="RedPhone_canceling_call">Atmečiamas skambutis</string>
+  <string name="RedPhone_canceling_call">Atsisakoma skambučio</string>
   <string name="RedPhone_call_rejected">Skambutis atmestas</string>
   <string name="RedPhone_ringing">Skambinama</string>
   <string name="RedPhone_busy">Užimta</string>
@@ -398,12 +481,17 @@
         Kelis kartus patikrinkite ar tai yra jūsų numeris! Mes ketiname jį patvirtinti, naudodami SMS.
     </string>
   <string name="RegistrationActivity_continue">Tęsti</string>
-  <string name="RegistrationActivity_edit">Redaguoti</string>
+  <string name="RegistrationActivity_edit">Taisyti</string>
+  <string name="RegistrationActivity_missing_google_play_services">Trūksta „Google Play“ paslaugų</string>
+  <string name="RegistrationActivity_this_device_is_missing_google_play_services">Šiame įrenginyje nėra „Google Play“ paslaugų. Jūs vis tiek galite naudoti Signal, tačiau tokia konfigūracija gali sąlygoti mažesnį patikimumą ir našumą.\n\nJeigu jūs nesate pažengęs naudotojas, nenaudojate atsarginių dalių Android ROM ar manote, jog matote šią klaidą, tuomet pagalbai ir nesklandumų šalinimui susisiekite su support@whispersystems.org.</string>
+  <string name="RegistrationActivity_i_understand">Aš suprantu</string>
+  <string name="RegistrationActivity_play_services_error">„Play“ paslaugų klaida</string>
+  <string name="RegistrationActivity_google_play_services_is_updating_or_unavailable">„Google Play“ paslaugos yra atnaujinamos arba laikinai neprieinamos. Prašome bandyti dar kartą.</string>
   <!--RegistrationProblemsActivity-->
   <string name="RegistrationProblemsActivity_possible_problems">Galimos problemos</string>
   <!--RegistrationProgressActivity-->
   <string name="RegistrationProgressActivity_verifying_number">Patvirtinamas numeris</string>
-  <string name="RegistrationProgressActivity_edit_s">Redaguoti %s</string>
+  <string name="RegistrationProgressActivity_edit_s">Taisyti %s</string>
   <string name="RegistrationProgressActivity_registration_complete">Registracija užbaigta!</string>
   <string name="RegistrationProgressActivity_you_must_enter_the_code_you_received_first">Iš pradžių, privalote įvesti gautą kodą</string>
   <string name="RegistrationProgressActivity_connecting">Jungiamasi</string>
@@ -443,24 +531,27 @@
   <string name="SmsMessageRecord_secure_session_reset_s">%s atstatė saugųjį seansą.</string>
   <string name="SmsMessageRecord_duplicate_message">Dviguba žinutė.</string>
   <!--ThreadRecord-->
+  <string name="ThreadRecord_group_updated">Grupė atnaujinta</string>
   <string name="ThreadRecord_left_the_group">išėjo iš grupės</string>
   <string name="ThreadRecord_secure_session_reset">Saugusis seansas atstatytas.</string>
   <string name="ThreadRecord_draft">Juodraštis:</string>
-  <string name="ThreadRecord_called">Tu skambinai</string>
-  <string name="ThreadRecord_called_you">Tau skambino</string>
+  <string name="ThreadRecord_called">Jūs skambinote</string>
+  <string name="ThreadRecord_called_you">Jums skambino</string>
   <string name="ThreadRecord_missed_call">Praleistas skambutis</string>
   <string name="ThreadRecord_media_message">Medijos žinutė</string>
-  <string name="ThreadRecord_s_is_on_signal_say_hey">%s naudoja Signal, sakyk labas!</string>
+  <string name="ThreadRecord_s_is_on_signal_say_hey">%s naudoja Signal, pasisveikinkite!</string>
   <string name="ThreadRecord_disappearing_message_time_updated_to_s">Išnykstančių žinučių laikas nustatytas į %s</string>
   <string name="ThreadRecord_your_safety_number_with_s_has_changed">Jūsų saugumo numeris su %s pasikeitė.</string>
   <!--UpdateApkReadyListener-->
+  <string name="UpdateApkReadyListener_Signal_update">Signal atnaujinimas</string>
+  <string name="UpdateApkReadyListener_a_new_version_of_signal_is_available_tap_to_update">Yra prieinama nauja Signal versija, bakstelėkite, norėdami atnaujinti</string>
   <!--VerifyIdentityActivity-->
   <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">Jūsų kontaktas naudoja seną Signal versiją. Prieš patvirtindami savo saugumo numerį, paprašykite, kad jis atnaujintų programėlę.</string>
   <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">Jūsų kontaktas naudoja naujesnę Signal versiją su nesuderinamu QR kodo formatu. Norint palyginti, prašome atnaujinti programėlę.</string>
   <string name="VerifyIdentityActivity_the_scanned_qr_code_is_not_a_correctly_formatted_safety_number">Nuskenuotas QR kodas nėra teisingai formatuotas saugumo numerio patvirtinimo kodas. Prašome bandyti skenuoti dar kartą.</string>
   <string name="VerifyIdentityActivity_share_safety_number_via">Dalintis saugumo numeriu per...</string>
   <string name="VerifyIdentityActivity_our_signal_safety_number">Mūsų Signal saugumo numeris:</string>
-  <string name="VerifyIdentityActivity_no_app_to_share_to">Nėra programos, kuri galėtų būti naudojama dalijinimuosi.</string>
+  <string name="VerifyIdentityActivity_no_app_to_share_to">Atrodo, kad neturite programėlių su kuriomis dalintis.</string>
   <string name="VerifyIdentityActivity_no_safety_number_to_compare_was_found_in_the_clipboard">Iškarpinėje palyginimui nebuvo rasta jokio saugumo numerio</string>
   <!--KeyExchangeInitiator-->
   <string name="KeyExchangeInitiator_initiate_despite_existing_request_question">Inicijuoti nepaisant esamos užklausos?</string>
@@ -493,22 +584,25 @@
   <string name="ApplicationMigrationService_system_database_import_is_complete">Sistemos duomenų bazės importavimas užbaigtas.</string>
   <!--KeyCachingService-->
   <string name="KeyCachingService_signal_passphrase_cached">Prilieskite, kad atvertumėte.</string>
+  <string name="KeyCachingService_signal_passphrase_cached_with_lock">Prilieskite, norėdami atverti arba prilieskite spyną, norėdami užverti.</string>
   <string name="KeyCachingService_passphrase_cached">Signal yra atrakinta</string>
-  <string name="KeyCachingService_lock">Užrakinti su slapta fraze</string>
+  <string name="KeyCachingService_lock">Užrakinti, naudojant slaptafrazę</string>
   <!--MediaPreviewActivity-->
-  <string name="MediaPreviewActivity_you">Tu</string>
+  <string name="MediaPreviewActivity_you">Jūs</string>
   <string name="MediaPreviewActivity_cant_display">Nepavyko peržiūrėti šio paveikslo</string>
   <string name="MediaPreviewActivity_unssuported_media_type">Nepalaikomas medijos tipas</string>
+  <string name="MediaPreviewActivity_draft">Juodraštis</string>
   <!--MessageNotifier-->
+  <string name="MessageNotifier_d_new_messages_in_d_conversations">%1$d naujų(-os) žinutės(-ių) %2$d pokalbyje(-iuose)</string>
   <string name="MessageNotifier_most_recent_from_s">Paskiausia nuo: %1$s</string>
   <string name="MessageNotifier_locked_message">Užrakinta žinutė</string>
   <string name="MessageNotifier_media_message_with_text">Medijos žinutė: %s</string>
-  <string name="MessageNotifier_no_subject">(Jokios temos)</string>
+  <string name="MessageNotifier_no_subject">(Nėra temos)</string>
   <string name="MessageNotifier_message_delivery_failed">Žinutės pristatymas nepavyko.</string>
   <string name="MessageNotifier_failed_to_deliver_message">Nepavyko pristatyti žinutės.</string>
   <string name="MessageNotifier_error_delivering_message">Klaida, pristatant žinutę.</string>
-  <string name="MessageNotifier_mark_all_as_read">Viską perskaičiau</string>
-  <string name="MessageNotifier_mark_read">Perskaičiau</string>
+  <string name="MessageNotifier_mark_all_as_read">Žymėti visas kaip skaitytas</string>
+  <string name="MessageNotifier_mark_read">Žymėti kaip skaitytą</string>
   <string name="MessageNotifier_media_message">Medijos žinutė</string>
   <string name="MessageNotifier_reply">Atsakyti</string>
   <!--MmsPreferencesFragment-->
@@ -517,16 +611,21 @@
   <string name="MmsPreferencesFragment__disabled">Išjungta</string>
   <string name="MmsPreferencesFragment__not_set">Nenustatyta</string>
   <string name="MmsPreferencesFragment__invalid_uri">Įvestas tekstas nebuvo teisingas URI</string>
+  <string name="MmsPreferencesFragment__invalid_host">Įvestas tekstas nebuvo teisingas serveris</string>
   <!--QuickResponseService-->
+  <string name="QuickResponseService_quick_response_unavailable_when_Signal_is_locked">Spartusis atsakymas neprieinamas, kai Signal yra užrakinta!</string>
   <string name="QuickResponseService_problem_sending_message">Problemos siunčiant žinutę!</string>
   <!--SingleRecipientNotificationBuilder-->
   <string name="SingleRecipientNotificationBuilder_signal">Signal</string>
   <string name="SingleRecipientNotificationBuilder_new_message">Nauja žinutė</string>
   <!--VideoPlayer-->
+  <string name="VideoPlayer_error_playing_video">Klaida, atkuriant vaizdo įrašą</string>
   <!--WebRtcCallScreen-->
+  <string name="WebRtcCallScreen_new_safety_numbers">Jūsų pokalbio su %1$s saugumo numeris pasikeitė. Tai gali reikšti, kad kažkas bando perimti jūsų susirašinėjimą arba, kad %2$s, tiesiog, iš naujo įdiegė Signal.</string>
   <string name="WebRtcCallScreen_you_may_wish_to_verify_this_contact">Jūs, tikriausiai, norėtumėte patvirtinti savo saugumo numerį su šiuo kontaktu.</string>
   <string name="WebRtcCallScreen_new_safety_number_title">Naujas saugumo numeris</string>
   <!--WebRtcCallControls-->
+  <string name="WebRtcCallControls_tap_to_enable_your_video">Bakstelėkite, norėdami įjungti savo vaizdą</string>
   <!--attachment_type_selector-->
   <string name="attachment_type_selector__image">Paveikslas</string>
   <string name="attachment_type_selector__image_description">Paveikslas</string>
@@ -542,6 +641,7 @@
   <string name="attachment_type_selector__location_description">Vieta</string>
   <string name="attachment_type_selector__gif">GIF</string>
   <string name="attachment_type_selector__gif_description">Gif</string>
+  <string name="attachment_type_selector__drawer_description">Perjungti priedų stalčių</string>
   <!--change_passphrase_activity-->
   <string name="change_passphrase_activity__old_passphrase">Sena slaptafrazė</string>
   <string name="change_passphrase_activity__new_passphrase">Nauja slaptafrazė</string>
@@ -572,12 +672,13 @@
   <string name="conversation_activity__compose_description">Žinutės kūrimas</string>
   <string name="conversation_activity__emoji_toggle_description">Perjungti jaustukų klaviatūrą</string>
   <string name="conversation_activity__attachment_thumbnail">Priedo miniatiūra</string>
+  <string name="conversation_activity__quick_attachment_drawer_toggle_camera_description">Perjungti sparčiosios kameros priedų stalčių</string>
   <string name="conversation_activity__quick_attachment_drawer_record_and_send_audio_description">Įrašyti ir siųsti garso įrašo priedą</string>
   <string name="conversation_activity__enable_signal_for_sms">Naudoti Signal SMS žinutėms</string>
   <!--conversation_input_panel-->
-  <string name="conversation_input_panel__slide_to_cancel">ATŠAUKITE SLINKDAMI</string>
+  <string name="conversation_input_panel__slide_to_cancel">SLINKITE, NORĖDAMI ATSISAKYTI</string>
   <!--conversation_item-->
-  <string name="conversation_item__mms_downloading_description">Medijos žinutė siunčiama</string>
+  <string name="conversation_item__mms_downloading_description">Atsiunčiama medijos žinutė</string>
   <string name="conversation_item__mms_image_description">Medijos žinutė</string>
   <string name="conversation_item__secure_message_description">Saugi žinutė</string>
   <!--conversation_item_sent-->
@@ -595,6 +696,7 @@
   <string name="audio_view__pause_accessibility_description">Pristabdyti</string>
   <string name="audio_view__download_accessibility_description">Atsisiųsti</string>
   <!--conversation_fragment_cab-->
+  <string name="conversation_fragment_cab__batch_selection_mode">Masinio pasirinkimo veiksena</string>
   <string name="conversation_fragment_cab__batch_selection_amount">%s pasirinkta</string>
   <!--conversation_fragment-->
   <string name="conversation_fragment__scroll_to_the_bottom_content_description">Slinkti į apačią</string>
@@ -612,11 +714,36 @@
   <string name="experience_upgrade_activity__continue">tęsti</string>
   <!--expiration-->
   <string name="expiration_off">Išjungta</string>
-  <string name="expiration_seconds_abbreviated">%ds</string>
-  <string name="expiration_minutes_abbreviated">%dm</string>
-  <string name="expiration_hours_abbreviated">%dh</string>
-  <string name="expiration_days_abbreviated">%dd</string>
-  <string name="expiration_weeks_abbreviated">%dsav.</string>
+  <plurals name="expiration_seconds">
+    <item quantity="one">%d sekundė</item>
+    <item quantity="few">%d sekundės</item>
+    <item quantity="other">%d sekundžių</item>
+  </plurals>
+  <string name="expiration_seconds_abbreviated">%d sek.</string>
+  <plurals name="expiration_minutes">
+    <item quantity="one">%d minutė</item>
+    <item quantity="few">%d minutės</item>
+    <item quantity="other">%d minučių</item>
+  </plurals>
+  <string name="expiration_minutes_abbreviated">%d min.</string>
+  <plurals name="expiration_hours">
+    <item quantity="one">%d valanda</item>
+    <item quantity="few">%d valandos</item>
+    <item quantity="other">%d valandų</item>
+  </plurals>
+  <string name="expiration_hours_abbreviated">%d val.</string>
+  <plurals name="expiration_days">
+    <item quantity="one">%d diena</item>
+    <item quantity="few">%d dienos</item>
+    <item quantity="other">%d dienų</item>
+  </plurals>
+  <string name="expiration_days_abbreviated">%d d.</string>
+  <plurals name="expiration_weeks">
+    <item quantity="one">%d savaitė</item>
+    <item quantity="few">%d savaitės</item>
+    <item quantity="other">%d savaičių</item>
+  </plurals>
+  <string name="expiration_weeks_abbreviated">%d sav.</string>
   <!--giphy_activity-->
   <string name="giphy_activity_toolbar__search_gifs_and_stickers">Ieškoti GIF ir paveikslėlių</string>
   <!--giphy_fragment-->
@@ -628,7 +755,7 @@
   <string name="log_submit_activity__log_fetch_failed">Nepavyko perskaityti žurnalo jūsų įrenginyje. Jūs vis dar galite naudoti ADB, kad vietoj to, gautumėte derinimo žurnalą.</string>
   <string name="log_submit_activity__thanks">Ačiū už jūsų pagalbą!</string>
   <string name="log_submit_activity__submitting">Pateikiama</string>
-  <string name="log_submit_activity__posting_logs">Siunčiamos dėtalės į gistą…</string>
+  <string name="log_submit_activity__posting_logs">Skelbiami žurnalai į gist…</string>
   <string name="log_submit_activity__no_browser_installed">Neįdiegta jokia naršyklė</string>
   <!--database_migration_activity-->
   <string name="database_migration_activity__would_you_like_to_import_your_existing_text_messages">Ar norėtumėte importuoti savo esamas tekstines žinutes į užšifruotą Signal duomenų bazę?</string>
@@ -650,9 +777,11 @@
   <!--load_more_header-->
   <string name="load_more_header__see_full_conversation">Rodyti visą pokalbį</string>
   <!--media_overview_activity-->
+  <string name="media_overview_activity__no_media">Nėra medijos</string>
   <!--message_recipients_list_item-->
   <string name="message_recipients_list_item__verify">PATVIRTINTI</string>
   <string name="message_recipients_list_item__resend">SIŲSTI IŠ NAUJO</string>
+  <string name="message_recipients_list_item__resending">Siunčiama iš naujo...</string>
   <!--GroupUtil-->
   <plurals name="GroupUtil_joined_the_group">
     <item quantity="one">%1$s prisijungė prie grupės.</item>
@@ -663,6 +792,8 @@
   <!--prompt_passphrase_activity-->
   <string name="prompt_passphrase_activity__unlock">Atrakinti</string>
   <!--prompt_mms_activity-->
+  <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">Tam, kad pristatytų mediją ir grupės žinutes per jūsų belaidį tiekėją, Signal reikalauja MMS nustatymų. Jūsų įrenginys nepadaro šios informacijos prieinamos, kas, dažniausiai, pasitvirtina užrakintiems įrenginiams ir ribotoms konfigūracijoms.</string>
+  <string name="prompt_mms_activity__to_send_media_and_group_messages_tap_ok">Norėdami siųsti mediją ir grupės žinutes, bakstelėkite \"Gerai\" ir užbaikite užklaustus nustatymus. Įprastai, jūsų tiekėjo MMS nustatymus galima rasti, ieškant \"jūsų tiekėjas APN\". Jums reikės tai atlikti tik vieną kartą.</string>
   <!--recipient_preferences_activity-->
   <string name="recipient_preference_activity__blocked">UŽBLOKUOTAS</string>
   <!--recipient_preferences-->
@@ -735,6 +866,10 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
 </string>
   <string name="registration_progress_activity__restrictive_firewall">Aptikta ribojanti užkarda.
 </string>
+  <string name="registration_progress_activity__if_you_are_connected_via_wifi_its_possible_that_there_is_a_firewall">
+        Jeigu esate prisijungę prie belaidžio (Wi-Fi) tinklo, tuomet gali būti, kad yra užkarda kuri blokuoja prieigą
+        prie Signal serverio. Pabandykite kitą tinklą arba mobiliųjų duomenų perdavimą.
+    </string>
   <string name="registration_progress_activity__signal_will_now_automatically_verify_your_number_with_a_confirmation_sms_message">
         Dabar, Signal automatiškai patvirtins jūsų numerį, naudojant patvirtinimo SMS žinutę.
     </string>
@@ -758,30 +893,32 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <string name="registration_progress_activity__check">Pažymėti</string>
   <!--recipients_panel-->
   <string name="recipients_panel__to"><small>Įveskite vardą ar numerį</small></string>
-  <string name="recipients_panel__add_members">Pridėti narius</string>
+  <string name="recipients_panel__add_members">Pridėti dalyvius</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s"><![CDATA[Jeigu norite patvirtinti savo ištisinio perdavimo šifravimo su %s saugumą, tuomet palyginkite aukščiau esančius skaičius su jo/jos įrenginyje esančiais skaičiais. Kitu atveju, galite nuskenuoti jo/jos telefone esantį kodą arba paprašyti, kad jis/ji nuskenuotų jūsų kodą. <a href="https://whispersystems.org/redirect/safety-numbers">Sužinokite daugiau apie saugumo numerių patvirtinimą</a>]]></string>
-  <string name="verify_display_fragment__tap_to_scan">Skenuoti</string>
+  <string name="verify_display_fragment__tap_to_scan">Bakstelėkite, norėdami nuskenuoti</string>
   <!--verify_identity-->
-  <string name="verify_identity__share_safety_number">Pasidalinti saugumo numerį</string>
+  <string name="verify_identity__share_safety_number">Dalintis saugumo numeriu</string>
   <!--message_details_header-->
   <string name="message_details_header__issues_need_your_attention">Kai kurios problemos reikalauja jūsų dėmesio.</string>
   <string name="message_details_header__sent">Išsiųsta</string>
   <string name="message_details_header__received">Gauta</string>
   <string name="message_details_header__disappears">Išnyksta</string>
-  <string name="message_details_header__via">su</string>
-  <string name="message_details_header__to">Kam?</string>
+  <string name="message_details_header__via">Per</string>
+  <string name="message_details_header__to">Kam:</string>
   <string name="message_details_header__from">Nuo:</string>
   <string name="message_details_header__with">Su:</string>
   <!--AndroidManifest.xml-->
   <string name="AndroidManifest__create_passphrase">Kurti slaptafrazę</string>
-  <string name="AndroidManifest__enter_passphrase">Įvesti slaptą frazę</string>
+  <string name="AndroidManifest__enter_passphrase">Įvesti slaptafrazę</string>
   <string name="AndroidManifest__select_contacts">Pasirinkti kontaktus</string>
-  <string name="AndroidManifest__signal_detected">Signal surastas</string>
+  <string name="AndroidManifest__signal_detected">Signal aptikta</string>
   <string name="AndroidManifest__change_passphrase">Pakeisti slaptafrazę</string>
   <string name="AndroidManifest__verify_safety_number">Patvirtinti saugumo numerį</string>
   <string name="AndroidManifest__log_submit">Pateikti derinimo žurnalą</string>
   <string name="AndroidManifest__media_preview">Medijos peržiūra</string>
+  <string name="AndroidManifest__all_media">Visa medija</string>
+  <string name="AndroidManifest__all_media_named">Visa medija su %1$s</string>
   <string name="AndroidManifest__message_details">Išsamesnė žinutės informacija</string>
   <string name="AndroidManifest__linked_devices">Susieti įrenginiai</string>
   <string name="AndroidManifest__invite_friends">Pakviesti draugus</string>
@@ -805,6 +942,11 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <string name="arrays__audio">Garso įrašai</string>
   <string name="arrays__video">Vaizdo įrašai</string>
   <!--plurals.xml-->
+  <plurals name="hours_ago">
+    <item quantity="one">%d valanda</item>
+    <item quantity="few">%d valandos</item>
+    <item quantity="other">%d valandų</item>
+  </plurals>
   <!--preferences.xml-->
   <string name="preferences__general">Bendra</string>
   <string name="preferences__sms_mms">SMS ir MMS</string>
@@ -817,9 +959,9 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <string name="preferences__replace_smiley_with_enter_key">Pakeisti šypsenėlės klavišą Enter (Įvedimo) klavišu</string>
   <string name="preferences__pref_enter_sends_title">Enter (Įvedimo) klavišas išsiunčia</string>
   <string name="preferences__pressing_the_enter_key_will_send_text_messages">Enter (Įvedimo) klavišo paspaudimas išsiųs tekstines žinutes</string>
-  <string name="preferences__display_settings">Išvaizdos nustatymai</string>
+  <string name="preferences__display_settings">Rodymo nustatymai</string>
   <string name="preferences__choose_identity">Pasirinkti tapatybę</string>
-  <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Pasirinkite adresatą iš adresų sąrašo.</string>
+  <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Pasirinkite kontaktą iš kontaktų sąrašo.</string>
   <string name="preferences__change_passphrase">Pakeisti slaptafrazę</string>
   <string name="preferences__change_your_passphrase">Pakeisti jūsų slaptafrazę</string>
   <string name="preferences__enable_passphrase">Įjungti slaptafrazę</string>
@@ -897,8 +1039,8 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <string name="preferences__signal_messages_and_calls">Signal žinutės ir skambučiai</string>
   <string name="preferences__free_private_messages_and_calls">Nemokamos privačios žinutės ir skambučiai Signal naudotojams</string>
   <string name="preferences__submit_debug_log">Pateikti derinimo žurnalą</string>
-  <string name="preferences__support_wifi_calling">„Wi-Fi skambučių“ suderinamumo režimas</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Įjunkite jei jūsų įrenginys siunčia SMS/MMS per WiFi tinklą (naudokite tik tuo atveju jei yra aktyvuota \"WiFi skambutis\" funkcija)</string>
+  <string name="preferences__support_wifi_calling">„Wi-Fi skambučių“ suderinamumo veiksena</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Įjunkite jeigu jūsų įrenginys siunčia SMS/MMS per WiFi tinklą (įjunkite tik tuo atveju jeigu jūsų įrenginyje yra aktyvuota \"WiFi skambučių\" funkcija)</string>
   <string name="preferences_app_protection__blocked_contacts">Užblokuoti kontaktai</string>
   <string name="preferences_app_protection__safety_numbers_approval">Saugumo numerių patvirtinimas</string>
   <string name="preferences_app_protecting__require_approval_of_new_safety_numbers_when_they_change">Reikalauti naujų saugumo numerių patvirtinimo, jiems pasikeitus</string>
@@ -910,18 +1052,21 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <string name="preferences_chats__message_trimming">Žinučių apkirpimas</string>
   <string name="preferences_advanced__use_system_emoji">Naudoti sistemos jaustukus</string>
   <string name="preferences_advanced__disable_signal_built_in_emoji_support">Išjungti Signal įtaisytą jaustukų palaikymą</string>
-  <string name="preferences_advanced__video_calling_beta">Video skambutis beta</string>
+  <string name="preferences_advanced__video_calling_beta">Vaizdo skambutis beta</string>
+  <string name="preferences_advanced__enable_support_for_next_generation_video_and_voice_calls">Sekančios kartos vaizdo ir balso skambučių palaikymas, kuomet abi pusės turi šią ypatybę įjungtą. Ši ypatybė yra beta stadijoje.</string>
+  <string name="preferences_advanced__relay_all_calls_through_the_signal_server_to_avoid_revealing_your_ip_address">Retransliuoti visus skambučius per Signal serverį, kad būtų išvengta jūsų IP adreso atskleidimo jūsų kontaktui. Įjungus, pablogės skambučių kokybė.</string>
+  <string name="preferences_advanced__always_relay_calls">Visada retransliuoti skambučius</string>
   <!--****************************************-->
   <!--menus-->
   <!--****************************************-->
   <!--contact_selection_list-->
-  <string name="contact_selection_list__menu_select_all">Pasirinkti viską</string>
-  <string name="contact_selection_list__menu_unselect_all">Atsirinkti viską</string>
+  <string name="contact_selection_list__menu_select_all">Žymėti visus</string>
+  <string name="contact_selection_list__menu_unselect_all">Nuimti žymėjimą nuo visų</string>
   <string name="contact_selection_list__header_signal_users">SIGNAL NAUDOTOJAI</string>
   <string name="contact_selection_list__header_other">VISI KONTAKTAI</string>
-  <string name="contact_selection_list__unknown_contact">Nauja žinute kam?</string>
+  <string name="contact_selection_list__unknown_contact">Nauja žinutė, skirta...</string>
   <!--contact_selection-->
-  <string name="contact_selection__menu_finished">Baigta</string>
+  <string name="contact_selection__menu_finished">Užbaigta</string>
   <!--refreshing push directory from menu-->
   <string name="push_directory__menu_refresh">Iš naujo įkelti kontaktų sąrašą</string>
   <!--conversation_callable_insecure-->
@@ -939,16 +1084,20 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <!--conversation_expiring_off-->
   <string name="conversation_expiring_off__disappearing_messages">Išnykstančios žinutės</string>
   <!--conversation_expiring_on-->
+  <string name="menu_conversation_expiring_on__messages_expiring">Nustojančios galioti žinutės</string>
   <!--conversation_insecure-->
   <string name="conversation_insecure__invite">Pakviesti</string>
   <!--conversation_insecure_no_push-->
   <string name="conversation_insecure__security">Saugumas</string>
   <!--conversation_list_batch-->
+  <string name="conversation_list_batch__menu_delete_selected">Ištrinti pasirinktus</string>
   <string name="conversation_list_batch__menu_select_all">Pasirinkti viską</string>
   <string name="conversation_list_batch_archive__menu_archive_selected">Archyvas pasirinktas</string>
+  <string name="conversation_list_batch_unarchive__menu_unarchive_selected">Išarchyvuoti pasirinktus</string>
   <!--conversation_list-->
   <string name="conversation_list__menu_search">Paieška</string>
   <!--conversation_list_item_view-->
+  <string name="conversation_list_item_view__contact_photo_image">Kontakto nuotraukos paveikslas</string>
   <string name="conversation_list_item_view__error_alert">Klaidos įspėjimas</string>
   <string name="conversation_list_item_view__archived">Archyvuota</string>
   <!--conversation_list_fragment-->
@@ -956,18 +1105,25 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <!--conversation_secure_verified-->
   <string name="conversation_secure_verified__menu_reset_secure_session">Atstatyti saugųjį seansą</string>
   <!--conversation_muted-->
+  <string name="conversation_muted__unmute">Įjungti pranešimus</string>
   <!--conversation_unmuted-->
   <string name="conversation_unmuted__mute_notifications">Nutildyti pranešimus</string>
   <!--conversation-->
   <string name="conversation__menu_add_attachment">Pridėti priedą</string>
+  <string name="conversation__menu_edit_group">Taisyti grupę</string>
   <string name="conversation__menu_leave_group">Išeiti iš grupės</string>
   <string name="conversation__menu_delete_thread">Ištrinti pokalbį</string>
+  <string name="conversation__menu_view_all_media">Visa medija</string>
   <string name="conversation__menu_conversation_settings">Pokalbio nustatymai</string>
   <!--conversation_popup-->
+  <string name="conversation_popup__menu_expand_popup">Išskleisti iškylantįjį langą</string>
   <!--conversation_callable_insecure-->
+  <string name="conversation_add_to_contacts__menu_add_to_contacts">Įtraukti į kontaktus</string>
   <!--conversation_group_options-->
   <string name="convesation_group_options__recipients_list">Gavėjų sąrašas</string>
+  <string name="conversation_group_options__delivery">Pristatymas</string>
   <string name="conversation_group_options__conversation">Pokalbis</string>
+  <string name="conversation_group_options__broadcast">Transliavimas</string>
   <!--key_scanning-->
   <string name="key_scanning__menu_compare">Palyginti</string>
   <string name="key_scanning__menu_display_your_qr_code">Rodyti jūsų QR kodą</string>
@@ -985,6 +1141,11 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Palyginti su iškarpine</string>
   <!--reminder_header-->
   <string name="reminder_header_outdated_build">Jūsų Signal versija yra pasenusi</string>
+  <plurals name="reminder_header_outdated_build_details">
+    <item quantity="one">Jūsų Signal versija nustos galioti po %d dienos. Bakstelėkite, norėdami atnaujinti į naujausią versiją.</item>
+    <item quantity="few">Jūsų Signal versija nustos galioti po %d dienų. Bakstelėkite, norėdami atnaujinti į naujausią versiją.</item>
+    <item quantity="other">Jūsų Signal versija nustos galioti po %d dienų. Bakstelėkite, norėdami atnaujinti į naujausią versiją.</item>
+  </plurals>
   <string name="reminder_header_outdated_build_details_today">Šiandien nustos galioti jūsų Signal versija. Bakstelėkite, kad atnaujintumėte į naujausią versiją.</string>
   <string name="reminder_header_expired_build">Jūsų Signal versijos galiojimas baigėsi!</string>
   <string name="reminder_header_expired_build_details">Žinutės daugiau nebebus siunčiamos sėkmingai. Bakstelėkite, kad atnaujintumėte į naujausią versiją.</string>
@@ -995,7 +1156,8 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <string name="reminder_header_sms_import_title">Importuoti sistemos SMS</string>
   <string name="reminder_header_sms_import_text">Bakstelėkite, kad nukopijuotumėte savo telefono SMS į Signal šifruotą duomenų bazę.</string>
   <string name="reminder_header_sms_import_button">IMPORTUOTI</string>
-  <string name="reminder_header_push_title">Įjungti Signal pokalbius bei žinutes</string>
+  <string name="reminder_header_push_title">Įjungti Signal skambučius ir žinutes</string>
+  <string name="reminder_header_push_text">Atnaujinkite savo bendravimo patyrimą.</string>
   <string name="reminder_header_push_button">ĮJUNGTI</string>
   <string name="reminder_header_invite_title">Pakviesti į Signal</string>
   <string name="reminder_header_invite_text">Perkelkite savo pokalbį su %1$s į kitą lygmenį.</string>
@@ -1007,14 +1169,15 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <!--media_preview-->
   <string name="media_preview__save_title">Įrašyti</string>
   <string name="media_preview__forward_title">Persiųsti</string>
+  <string name="media_preview__all_media_title">Visa medija</string>
   <!--media_overview-->
-  <string name="media_overview__save_all">Viską išsaugoti</string>
+  <string name="media_overview__save_all">Įrašyti visus</string>
   <!--media_preview_activity-->
   <string name="media_preview_activity__media_content_description">Medijos peržiūra</string>
   <!--new_conversation_activity-->
   <string name="new_conversation_activity__refresh">Įkelti iš naujo</string>
   <!--redphone_audio_popup_menu-->
-  <string name="redphone_audio_popup_menu__handset">Garsiakalbis</string>
+  <string name="redphone_audio_popup_menu__handset">Telefono ragelis</string>
   <string name="redphone_audio_popup_menu__headset">Ausinės</string>
   <string name="redphone_audio_popup_menu__speaker">Garsiakalbis</string>
   <!--Trimmer-->
@@ -1022,5 +1185,6 @@ yra prisijungęs prie belaidžio (Wi-Fi) arba duomenų perdavimo tinklo.
   <string name="trimmer__deleting_old_messages">Ištrinamos senos žinutės...</string>
   <string name="trimmer__old_messages_successfully_deleted">Senos žinutės sėkmingai ištrintos</string>
   <!--transport_selection_list_item-->
+  <string name="transport_selection_list_item__transport_icon">Perdavimo piktograma</string>
   <!--EOF-->
 </resources>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -359,6 +359,8 @@ importá-lo novamente resultará em mensagens duplicadas.</string>
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Recebeu uma mensagem cifrada com uma versão anterior de Signal, que já não é suportada. Por favor peça ao remetente para actualizar para a versão mais recente e reenviar a mensagem.</string>
   <string name="MessageRecord_left_group">Abandonou o grupo.</string>
+  <string name="MessageRecord_you_updated_group">Tu atualizaste o grupo.</string>
+  <string name="MessageRecord_s_updated_group">%s atualizou o grupo.</string>
   <string name="MessageRecord_s_called_you">%s ligou-lhe</string>
   <string name="MessageRecord_called_s">Ligou para %s</string>
   <string name="MessageRecord_missed_call_from">Chamada perdida de %s</string>
@@ -504,6 +506,7 @@ Mensagem de troca de chave inválida para esta versão do protocolo.
   <string name="SmsMessageRecord_secure_session_reset_s">%s reiniciou a sessão segura.</string>
   <string name="SmsMessageRecord_duplicate_message">Mensagem duplicada.</string>
   <!--ThreadRecord-->
+  <string name="ThreadRecord_group_updated">Grupo atualizado</string>
   <string name="ThreadRecord_left_the_group">Abandonou o grupo</string>
   <string name="ThreadRecord_secure_session_reset">Sessão segura reiniciada.</string>
   <string name="ThreadRecord_draft">Rascunho:</string>
@@ -748,6 +751,7 @@ Mensagem de troca de chave inválida para esta versão do protocolo.
   <!--message_recipients_list_item-->
   <string name="message_recipients_list_item__verify">VERIFICAR</string>
   <string name="message_recipients_list_item__resend">REENVIAR</string>
+  <string name="message_recipients_list_item__resending">A reenviar...</string>
   <!--GroupUtil-->
   <plurals name="GroupUtil_joined_the_group">
     <item quantity="one">%1$s juntou-se ao grupo.</item>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -374,6 +374,8 @@ Vei pierde orice informație care se află în instalarea curentă de Signal și
   <!--MessageRecord-->
   <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Ai primit un mesaj care a fost criptat cu o versiune mai veche de Signal care nu mai este suportată. Roagă-l pe expeditor să-și actualizeze aplicația la ultima versiune și să retrimită mesajul.</string>
   <string name="MessageRecord_left_group">Ai parăsit grupul.</string>
+  <string name="MessageRecord_you_updated_group">Ai actualizat grupul.</string>
+  <string name="MessageRecord_s_updated_group">%s a actualizat grupul.</string>
   <string name="MessageRecord_s_called_you">%s te-a apelat</string>
   <string name="MessageRecord_called_s">Apel %s</string>
   <string name="MessageRecord_missed_call_from">Apel ratat de la %s</string>
@@ -517,6 +519,7 @@ Am primit mesajul conform căruia schimbul de chei a avut loc pentru o versiune 
   <string name="SmsMessageRecord_secure_session_reset_s">%s a resetat sesiunea securizată.</string>
   <string name="SmsMessageRecord_duplicate_message">Mesaj duplicat.</string>
   <!--ThreadRecord-->
+  <string name="ThreadRecord_group_updated">Grupul a fost actualizat</string>
   <string name="ThreadRecord_left_the_group">A ieșit din grup</string>
   <string name="ThreadRecord_secure_session_reset">Sesiune securizată resetată.</string>
   <string name="ThreadRecord_draft">Ciornă:</string>
@@ -766,6 +769,7 @@ Am primit mesajul conform căruia schimbul de chei a avut loc pentru o versiune 
   <!--message_recipients_list_item-->
   <string name="message_recipients_list_item__verify">VERIFICĂ</string>
   <string name="message_recipients_list_item__resend">RETRIMITE</string>
+  <string name="message_recipients_list_item__resending">Se trimite din nou...</string>
   <!--GroupUtil-->
   <plurals name="GroupUtil_joined_the_group">
     <item quantity="one">%1$s s-a alăturat grupului.</item>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
-  <string name="app_name">暗号</string>
+  <string name="app_name">Signal</string>
   <string name="yes">是</string>
   <string name="no">否</string>
   <string name="delete">删除</string>

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -188,6 +188,7 @@ public class ApplicationContext extends MultiDexApplication implements Dependenc
       add("MI 4LTE"); // Xiami Mi4 #6241
       add("Redmi Note 3"); // Redmi Note 3 #6241
       add("SM-G900F"); // Samsung Galaxy S5 #6241
+      add("g3_kt_kr"); // LG G3 #6241
     }};
 
     Set<String> OPEN_SL_ES_BLACKLIST = new HashSet<String>() {{

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -189,6 +189,8 @@ public class ApplicationContext extends MultiDexApplication implements Dependenc
       add("Redmi Note 3"); // Redmi Note 3 #6241
       add("SM-G900F"); // Samsung Galaxy S5 #6241
       add("g3_kt_kr"); // LG G3 #6241
+      add("SM-G930F"); // Samsung Galaxy S7 #6241
+      add("Xperia SP"); // Sony Xperia SP #6241
     }};
 
     Set<String> OPEN_SL_ES_BLACKLIST = new HashSet<String>() {{

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -191,6 +191,7 @@ public class ApplicationContext extends MultiDexApplication implements Dependenc
       add("g3_kt_kr"); // LG G3 #6241
       add("SM-G930F"); // Samsung Galaxy S7 #6241
       add("Xperia SP"); // Sony Xperia SP #6241
+      add("Nexus 6"); // Nexus 6
     }};
 
     Set<String> OPEN_SL_ES_BLACKLIST = new HashSet<String>() {{

--- a/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
+++ b/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
@@ -748,7 +748,11 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       else                   this.lockManager.updatePhoneState(LockManager.PhoneState.IN_CALL);
     }
 
-    if (localVideoEnabled && !audioManager.isSpeakerphoneOn() && !audioManager.isBluetoothScoOn()) {
+    if (localVideoEnabled &&
+        !audioManager.isSpeakerphoneOn() &&
+        !audioManager.isBluetoothScoOn() &&
+        !audioManager.isWiredHeadsetOn())
+    {
       audioManager.setSpeakerphoneOn(true);
     }
 

--- a/src/org/thoughtcrime/securesms/webrtc/VoiceCallShare.java
+++ b/src/org/thoughtcrime/securesms/webrtc/VoiceCallShare.java
@@ -1,0 +1,48 @@
+package org.thoughtcrime.securesms.webrtc;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.database.Cursor;
+import android.os.Bundle;
+import android.provider.ContactsContract;
+import android.text.TextUtils;
+
+import org.thoughtcrime.securesms.WebRtcCallActivity;
+import org.thoughtcrime.securesms.service.WebRtcCallService;
+
+public class VoiceCallShare extends Activity {
+  
+  private static final String TAG = VoiceCallShare.class.getSimpleName();
+  
+  @Override
+  public void onCreate(Bundle icicle) {
+    super.onCreate(icicle);
+
+    if (getIntent().getData() != null && "content".equals(getIntent().getData().getScheme())) {
+      Cursor cursor = null;
+      
+      try {
+        cursor = getContentResolver().query(getIntent().getData(), null, null, null, null);
+
+        if (cursor != null && cursor.moveToNext()) {
+          String destination = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.Data.DATA1));
+          
+          if (!TextUtils.isEmpty(destination)) {
+            Intent serviceIntent = new Intent(this, WebRtcCallService.class);
+            serviceIntent.setAction(WebRtcCallService.ACTION_OUTGOING_CALL);
+            serviceIntent.putExtra(WebRtcCallService.EXTRA_REMOTE_NUMBER, destination);
+            startService(serviceIntent);
+
+            Intent activityIntent = new Intent(this, WebRtcCallActivity.class);
+            activityIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(activityIntent);
+          }
+        }
+      } finally {
+        if (cursor != null) cursor.close();
+      }
+    }
+    
+    finish();
+  }
+}


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Galaxy Express Prime, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This pull request makes the plaintext export more compatible with the export from SMS Back and Restore. It adds a readable date, as well as the contact name.